### PR TITLE
Fix typos where "Entities" is misspelled as "Entites"

### DIFF
--- a/Myriad.ECS/Queries/IQuery.cs
+++ b/Myriad.ECS/Queries/IQuery.cs
@@ -214,7 +214,7 @@ namespace Myriad.ECS.Worlds
 						var start = b * batchSize;
 						var end = Math.Min(start + batchSize, entityCount);
 						var batchCount = end - start;
-						var eMem = chunk.GetEntitesMemory(start, batchCount);
+						var eMem = chunk.GetEntitiesMemory(start, batchCount);
 
 						var item = new WorkItem1<TQ, T0>(
 							eMem,
@@ -536,7 +536,7 @@ namespace Myriad.ECS.Worlds
 						var start = b * batchSize;
 						var end = Math.Min(start + batchSize, entityCount);
 						var batchCount = end - start;
-						var eMem = chunk.GetEntitesMemory(start, batchCount);
+						var eMem = chunk.GetEntitiesMemory(start, batchCount);
 
 						var item = new WorkItem2<TQ, T0, T1>(
 							eMem,
@@ -879,7 +879,7 @@ namespace Myriad.ECS.Worlds
 						var start = b * batchSize;
 						var end = Math.Min(start + batchSize, entityCount);
 						var batchCount = end - start;
-						var eMem = chunk.GetEntitesMemory(start, batchCount);
+						var eMem = chunk.GetEntitiesMemory(start, batchCount);
 
 						var item = new WorkItem3<TQ, T0, T1, T2>(
 							eMem,
@@ -1243,7 +1243,7 @@ namespace Myriad.ECS.Worlds
 						var start = b * batchSize;
 						var end = Math.Min(start + batchSize, entityCount);
 						var batchCount = end - start;
-						var eMem = chunk.GetEntitesMemory(start, batchCount);
+						var eMem = chunk.GetEntitiesMemory(start, batchCount);
 
 						var item = new WorkItem4<TQ, T0, T1, T2, T3>(
 							eMem,
@@ -1628,7 +1628,7 @@ namespace Myriad.ECS.Worlds
 						var start = b * batchSize;
 						var end = Math.Min(start + batchSize, entityCount);
 						var batchCount = end - start;
-						var eMem = chunk.GetEntitesMemory(start, batchCount);
+						var eMem = chunk.GetEntitiesMemory(start, batchCount);
 
 						var item = new WorkItem5<TQ, T0, T1, T2, T3, T4>(
 							eMem,
@@ -2034,7 +2034,7 @@ namespace Myriad.ECS.Worlds
 						var start = b * batchSize;
 						var end = Math.Min(start + batchSize, entityCount);
 						var batchCount = end - start;
-						var eMem = chunk.GetEntitesMemory(start, batchCount);
+						var eMem = chunk.GetEntitiesMemory(start, batchCount);
 
 						var item = new WorkItem6<TQ, T0, T1, T2, T3, T4, T5>(
 							eMem,
@@ -2461,7 +2461,7 @@ namespace Myriad.ECS.Worlds
 						var start = b * batchSize;
 						var end = Math.Min(start + batchSize, entityCount);
 						var batchCount = end - start;
-						var eMem = chunk.GetEntitesMemory(start, batchCount);
+						var eMem = chunk.GetEntitiesMemory(start, batchCount);
 
 						var item = new WorkItem7<TQ, T0, T1, T2, T3, T4, T5, T6>(
 							eMem,
@@ -2909,7 +2909,7 @@ namespace Myriad.ECS.Worlds
 						var start = b * batchSize;
 						var end = Math.Min(start + batchSize, entityCount);
 						var batchCount = end - start;
-						var eMem = chunk.GetEntitesMemory(start, batchCount);
+						var eMem = chunk.GetEntitiesMemory(start, batchCount);
 
 						var item = new WorkItem8<TQ, T0, T1, T2, T3, T4, T5, T6, T7>(
 							eMem,
@@ -3378,7 +3378,7 @@ namespace Myriad.ECS.Worlds
 						var start = b * batchSize;
 						var end = Math.Min(start + batchSize, entityCount);
 						var batchCount = end - start;
-						var eMem = chunk.GetEntitesMemory(start, batchCount);
+						var eMem = chunk.GetEntitiesMemory(start, batchCount);
 
 						var item = new WorkItem9<TQ, T0, T1, T2, T3, T4, T5, T6, T7, T8>(
 							eMem,
@@ -3868,7 +3868,7 @@ namespace Myriad.ECS.Worlds
 						var start = b * batchSize;
 						var end = Math.Min(start + batchSize, entityCount);
 						var batchCount = end - start;
-						var eMem = chunk.GetEntitesMemory(start, batchCount);
+						var eMem = chunk.GetEntitiesMemory(start, batchCount);
 
 						var item = new WorkItem10<TQ, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(
 							eMem,
@@ -4379,7 +4379,7 @@ namespace Myriad.ECS.Worlds
 						var start = b * batchSize;
 						var end = Math.Min(start + batchSize, entityCount);
 						var batchCount = end - start;
-						var eMem = chunk.GetEntitesMemory(start, batchCount);
+						var eMem = chunk.GetEntitiesMemory(start, batchCount);
 
 						var item = new WorkItem11<TQ, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
 							eMem,
@@ -4911,7 +4911,7 @@ namespace Myriad.ECS.Worlds
 						var start = b * batchSize;
 						var end = Math.Min(start + batchSize, entityCount);
 						var batchCount = end - start;
-						var eMem = chunk.GetEntitesMemory(start, batchCount);
+						var eMem = chunk.GetEntitiesMemory(start, batchCount);
 
 						var item = new WorkItem12<TQ, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
 							eMem,
@@ -5464,7 +5464,7 @@ namespace Myriad.ECS.Worlds
 						var start = b * batchSize;
 						var end = Math.Min(start + batchSize, entityCount);
 						var batchCount = end - start;
-						var eMem = chunk.GetEntitesMemory(start, batchCount);
+						var eMem = chunk.GetEntitiesMemory(start, batchCount);
 
 						var item = new WorkItem13<TQ, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
 							eMem,
@@ -6038,7 +6038,7 @@ namespace Myriad.ECS.Worlds
 						var start = b * batchSize;
 						var end = Math.Min(start + batchSize, entityCount);
 						var batchCount = end - start;
-						var eMem = chunk.GetEntitesMemory(start, batchCount);
+						var eMem = chunk.GetEntitiesMemory(start, batchCount);
 
 						var item = new WorkItem14<TQ, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
 							eMem,
@@ -6633,7 +6633,7 @@ namespace Myriad.ECS.Worlds
 						var start = b * batchSize;
 						var end = Math.Min(start + batchSize, entityCount);
 						var batchCount = end - start;
-						var eMem = chunk.GetEntitesMemory(start, batchCount);
+						var eMem = chunk.GetEntitiesMemory(start, batchCount);
 
 						var item = new WorkItem15<TQ, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
 							eMem,
@@ -7249,7 +7249,7 @@ namespace Myriad.ECS.Worlds
 						var start = b * batchSize;
 						var end = Math.Min(start + batchSize, entityCount);
 						var batchCount = end - start;
-						var eMem = chunk.GetEntitesMemory(start, batchCount);
+						var eMem = chunk.GetEntitiesMemory(start, batchCount);
 
 						var item = new WorkItem16<TQ, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
 							eMem,

--- a/Myriad.ECS/Queries/IQuery.tt
+++ b/Myriad.ECS/Queries/IQuery.tt
@@ -233,7 +233,7 @@ namespace Myriad.ECS.Worlds
 						var start = b * batchSize;
 						var end = Math.Min(start + batchSize, entityCount);
 						var batchCount = end - start;
-						var eMem = chunk.GetEntitesMemory(start, batchCount);
+						var eMem = chunk.GetEntitiesMemory(start, batchCount);
 
 						var item = new <#= workItemName #>(
 							eMem,

--- a/Myriad.ECS/Worlds/Chunks/Chunk.cs
+++ b/Myriad.ECS/Worlds/Chunks/Chunk.cs
@@ -129,7 +129,7 @@ internal sealed class Chunk
     {
         var index = info.RowIndex;
 
-        // No work to do if there are no other entites
+        // No work to do if there are no other entities
         EntityCount -= 1;
         if (EntityCount == 0)
         {

--- a/Myriad.ECS/Worlds/Chunks/Chunk.cs
+++ b/Myriad.ECS/Worlds/Chunks/Chunk.cs
@@ -204,7 +204,7 @@ internal sealed class Chunk
     }
 #endregion
 
-    public Memory<Entity> GetEntitesMemory(int start, int count)
+    public Memory<Entity> GetEntitiesMemory(int start, int count)
     {
         if (start + count > EntityCount)
             throw new ArgumentException("start + count is more than the number of entities", nameof(count));


### PR DESCRIPTION
This fixes two minor typos I noticed when updating my fork.
The first is related to Chunk.EntitiesMemory() being misspelled and the second is a similar typo in a comment.