### PR TITLE
Component Level Block

### DIFF
--- a/Myriad.ECS/EntityId.cs
+++ b/Myriad.ECS/EntityId.cs
@@ -266,7 +266,7 @@ public readonly partial struct EntityId
         where T : IComponent
     {
         ref var entityInfo = ref world.GetEntityInfo(this);
-        entityInfo.Chunk.Archetype.Block();
+        entityInfo.Chunk.Archetype.Block(ComponentID<T>.ID);
         return entityInfo.Chunk.GetRefT<T>(this, entityInfo.RowIndex);
     }
 
@@ -323,7 +323,7 @@ public readonly partial struct EntityId
             return null;
 
         ref var entityInfo = ref world.GetEntityInfo(this);
-        entityInfo.Chunk.Archetype.Block();
+        entityInfo.Chunk.Archetype.Block(id);
         return entityInfo.Chunk.GetComponentArray(id).GetValue(entityInfo.RowIndex);
     }
 }

--- a/Myriad.ECS/Locks/IWorldArchetypeSafetyManager.cs
+++ b/Myriad.ECS/Locks/IWorldArchetypeSafetyManager.cs
@@ -1,4 +1,5 @@
-﻿using Myriad.ECS.Worlds.Archetypes;
+﻿using Myriad.ECS.IDs;
+using Myriad.ECS.Worlds.Archetypes;
 
 namespace Myriad.ECS.Locks;
 
@@ -12,6 +13,13 @@ public interface IWorldArchetypeSafetyManager
     /// </summary>
     /// <param name="archetype"></param>
     void Block(Archetype archetype);
+
+    /// <summary>
+    /// Wait for multithreaded work which is accessing a specific component in a specific archetype to finish
+    /// </summary>
+    /// <param name="archetype"></param>
+    /// <param name="id"></param>
+    void Block(Archetype archetype, ComponentID id);
 }
 
 /// <summary>
@@ -22,6 +30,11 @@ public class DefaultWorldArchetypeSafetyManager
 {
     /// <inheritdoc />
     public void Block(Archetype archetype)
+    {
+    }
+
+    /// <inheritdoc />
+    public void Block(Archetype archetype, ComponentID id)
     {
     }
 }

--- a/Myriad.ECS/Myriad.ECS.csproj
+++ b/Myriad.ECS/Myriad.ECS.csproj
@@ -10,7 +10,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>Myriad.ECS</Title>
     <Authors>Martin Evans</Authors>
-    <Version>46.1.1</Version>
+    <Version>46.2.0</Version>
     <Description>Myriad.ECS is a high performance Entity Component System (ECS).</Description>
     <PackageProjectUrl>https://github.com/martindevans/Myriad.ECS</PackageProjectUrl>
     <RepositoryUrl>https://github.com/martindevans/Myriad.ECS</RepositoryUrl>

--- a/Myriad.ECS/Myriad.ECS.csproj
+++ b/Myriad.ECS/Myriad.ECS.csproj
@@ -10,7 +10,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>Myriad.ECS</Title>
     <Authors>Martin Evans</Authors>
-    <Version>46.2.0</Version>
+    <Version>47.0.0</Version>
     <Description>Myriad.ECS is a high performance Entity Component System (ECS).</Description>
     <PackageProjectUrl>https://github.com/martindevans/Myriad.ECS</PackageProjectUrl>
     <RepositoryUrl>https://github.com/martindevans/Myriad.ECS</RepositoryUrl>

--- a/Myriad.ECS/Queries/ChunkHandle.cs
+++ b/Myriad.ECS/Queries/ChunkHandle.cs
@@ -125,5 +125,14 @@ public readonly ref partial struct ChunkHandle
         {
             return _chunk.GetEntityArray();
         }
+
+        /// <summary>
+        /// Get the raw array storing entity ID data. Accessing beyond the entity count will be junk data.
+        /// </summary>
+        /// <returns></returns>
+        public EntityId[] GetEntityIdArray()
+        {
+            return _chunk.GetEntityIdArray();
+        }
     }
 }

--- a/Myriad.ECS/Queries/IChunkQuery.cs
+++ b/Myriad.ECS/Queries/IChunkQuery.cs
@@ -161,7 +161,8 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -239,7 +240,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
 
 				count += archetype.EntityCount;
 
@@ -503,7 +504,9 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -584,7 +587,8 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
 
 				count += archetype.EntityCount;
 
@@ -864,7 +868,10 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -948,7 +955,9 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
 
 				count += archetype.EntityCount;
 
@@ -1244,7 +1253,11 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -1331,7 +1344,10 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
 
 				count += archetype.EntityCount;
 
@@ -1643,7 +1659,12 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -1733,7 +1754,11 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
 
 				count += archetype.EntityCount;
 
@@ -2061,7 +2086,13 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -2154,7 +2185,12 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
 
 				count += archetype.EntityCount;
 
@@ -2498,7 +2534,14 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -2594,7 +2637,13 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
 
 				count += archetype.EntityCount;
 
@@ -2954,7 +3003,15 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -3053,7 +3110,14 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
 
 				count += archetype.EntityCount;
 
@@ -3429,7 +3493,16 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -3531,7 +3604,15 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
 
 				count += archetype.EntityCount;
 
@@ -3923,7 +4004,17 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -4028,7 +4119,16 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
 
 				count += archetype.EntityCount;
 
@@ -4436,7 +4536,18 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -4544,7 +4655,17 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
 
 				count += archetype.EntityCount;
 
@@ -4968,7 +5089,19 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -5079,7 +5212,18 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
 
 				count += archetype.EntityCount;
 
@@ -5519,7 +5663,20 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -5633,7 +5790,19 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
 
 				count += archetype.EntityCount;
 
@@ -6089,7 +6258,21 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(ComponentID<T13>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -6206,7 +6389,20 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(ComponentID<T13>.ID);
 
 				count += archetype.EntityCount;
 
@@ -6678,7 +6874,22 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(ComponentID<T13>.ID);
+				archetype.Block(ComponentID<T14>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -6798,7 +7009,21 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(ComponentID<T13>.ID);
+				archetype.Block(ComponentID<T14>.ID);
 
 				count += archetype.EntityCount;
 
@@ -7286,7 +7511,23 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(ComponentID<T13>.ID);
+				archetype.Block(ComponentID<T14>.ID);
+				archetype.Block(ComponentID<T15>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -7409,7 +7650,22 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(ComponentID<T13>.ID);
+				archetype.Block(ComponentID<T14>.ID);
+				archetype.Block(ComponentID<T15>.ID);
 
 				count += archetype.EntityCount;
 

--- a/Myriad.ECS/Queries/IChunkQuery.tt
+++ b/Myriad.ECS/Queries/IChunkQuery.tt
@@ -217,7 +217,17 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
+
+<# if (sumij == 0) { #>
 				archetype.Block();
+<# } #>
+<# for (var k = 0; k < sumij; k++)
+{
+#>
+				archetype.Block(ComponentID<T<#= k #>>.ID);
+<#
+}
+#>
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -283,7 +293,16 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
+<# if (sumij == 0) { #>
 				archetype.Block();
+<# } #>
+<# for (var k = 0; k < sumij; k++)
+{
+#>
+				archetype.Block(ComponentID<T<#= k #>>.ID);
+<#
+}
+#>
 
 				count += archetype.EntityCount;
 

--- a/Myriad.ECS/Queries/IQuery.cs
+++ b/Myriad.ECS/Queries/IQuery.cs
@@ -211,7 +211,7 @@ namespace Myriad.ECS.Worlds
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(c0);
 
 				count += archetype.EntityCount;
 
@@ -799,8 +799,8 @@ namespace Myriad.ECS.Worlds
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(c0);
+				archetype.Block(c1);
 
 				count += archetype.EntityCount;
 
@@ -1421,9 +1421,9 @@ namespace Myriad.ECS.Worlds
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(c0);
+				archetype.Block(c1);
+				archetype.Block(c2);
 
 				count += archetype.EntityCount;
 
@@ -2077,10 +2077,10 @@ namespace Myriad.ECS.Worlds
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(c0);
+				archetype.Block(c1);
+				archetype.Block(c2);
+				archetype.Block(c3);
 
 				count += archetype.EntityCount;
 
@@ -2767,11 +2767,11 @@ namespace Myriad.ECS.Worlds
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(c0);
+				archetype.Block(c1);
+				archetype.Block(c2);
+				archetype.Block(c3);
+				archetype.Block(c4);
 
 				count += archetype.EntityCount;
 
@@ -3491,12 +3491,12 @@ namespace Myriad.ECS.Worlds
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(c0);
+				archetype.Block(c1);
+				archetype.Block(c2);
+				archetype.Block(c3);
+				archetype.Block(c4);
+				archetype.Block(c5);
 
 				count += archetype.EntityCount;
 
@@ -4249,13 +4249,13 @@ namespace Myriad.ECS.Worlds
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(c0);
+				archetype.Block(c1);
+				archetype.Block(c2);
+				archetype.Block(c3);
+				archetype.Block(c4);
+				archetype.Block(c5);
+				archetype.Block(c6);
 
 				count += archetype.EntityCount;
 
@@ -5041,14 +5041,14 @@ namespace Myriad.ECS.Worlds
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(c0);
+				archetype.Block(c1);
+				archetype.Block(c2);
+				archetype.Block(c3);
+				archetype.Block(c4);
+				archetype.Block(c5);
+				archetype.Block(c6);
+				archetype.Block(c7);
 
 				count += archetype.EntityCount;
 
@@ -5867,15 +5867,15 @@ namespace Myriad.ECS.Worlds
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(c0);
+				archetype.Block(c1);
+				archetype.Block(c2);
+				archetype.Block(c3);
+				archetype.Block(c4);
+				archetype.Block(c5);
+				archetype.Block(c6);
+				archetype.Block(c7);
+				archetype.Block(c8);
 
 				count += archetype.EntityCount;
 
@@ -6727,16 +6727,16 @@ namespace Myriad.ECS.Worlds
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(c0);
+				archetype.Block(c1);
+				archetype.Block(c2);
+				archetype.Block(c3);
+				archetype.Block(c4);
+				archetype.Block(c5);
+				archetype.Block(c6);
+				archetype.Block(c7);
+				archetype.Block(c8);
+				archetype.Block(c9);
 
 				count += archetype.EntityCount;
 
@@ -7621,17 +7621,17 @@ namespace Myriad.ECS.Worlds
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(c0);
+				archetype.Block(c1);
+				archetype.Block(c2);
+				archetype.Block(c3);
+				archetype.Block(c4);
+				archetype.Block(c5);
+				archetype.Block(c6);
+				archetype.Block(c7);
+				archetype.Block(c8);
+				archetype.Block(c9);
+				archetype.Block(c10);
 
 				count += archetype.EntityCount;
 
@@ -8549,18 +8549,18 @@ namespace Myriad.ECS.Worlds
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(c0);
+				archetype.Block(c1);
+				archetype.Block(c2);
+				archetype.Block(c3);
+				archetype.Block(c4);
+				archetype.Block(c5);
+				archetype.Block(c6);
+				archetype.Block(c7);
+				archetype.Block(c8);
+				archetype.Block(c9);
+				archetype.Block(c10);
+				archetype.Block(c11);
 
 				count += archetype.EntityCount;
 
@@ -9511,19 +9511,19 @@ namespace Myriad.ECS.Worlds
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(c0);
+				archetype.Block(c1);
+				archetype.Block(c2);
+				archetype.Block(c3);
+				archetype.Block(c4);
+				archetype.Block(c5);
+				archetype.Block(c6);
+				archetype.Block(c7);
+				archetype.Block(c8);
+				archetype.Block(c9);
+				archetype.Block(c10);
+				archetype.Block(c11);
+				archetype.Block(c12);
 
 				count += archetype.EntityCount;
 
@@ -10507,20 +10507,20 @@ namespace Myriad.ECS.Worlds
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
-				archetype.Block(ComponentID<T13>.ID);
+				archetype.Block(c0);
+				archetype.Block(c1);
+				archetype.Block(c2);
+				archetype.Block(c3);
+				archetype.Block(c4);
+				archetype.Block(c5);
+				archetype.Block(c6);
+				archetype.Block(c7);
+				archetype.Block(c8);
+				archetype.Block(c9);
+				archetype.Block(c10);
+				archetype.Block(c11);
+				archetype.Block(c12);
+				archetype.Block(c13);
 
 				count += archetype.EntityCount;
 
@@ -11537,21 +11537,21 @@ namespace Myriad.ECS.Worlds
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
-				archetype.Block(ComponentID<T13>.ID);
-				archetype.Block(ComponentID<T14>.ID);
+				archetype.Block(c0);
+				archetype.Block(c1);
+				archetype.Block(c2);
+				archetype.Block(c3);
+				archetype.Block(c4);
+				archetype.Block(c5);
+				archetype.Block(c6);
+				archetype.Block(c7);
+				archetype.Block(c8);
+				archetype.Block(c9);
+				archetype.Block(c10);
+				archetype.Block(c11);
+				archetype.Block(c12);
+				archetype.Block(c13);
+				archetype.Block(c14);
 
 				count += archetype.EntityCount;
 
@@ -12601,22 +12601,22 @@ namespace Myriad.ECS.Worlds
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
-				archetype.Block(ComponentID<T13>.ID);
-				archetype.Block(ComponentID<T14>.ID);
-				archetype.Block(ComponentID<T15>.ID);
+				archetype.Block(c0);
+				archetype.Block(c1);
+				archetype.Block(c2);
+				archetype.Block(c3);
+				archetype.Block(c4);
+				archetype.Block(c5);
+				archetype.Block(c6);
+				archetype.Block(c7);
+				archetype.Block(c8);
+				archetype.Block(c9);
+				archetype.Block(c10);
+				archetype.Block(c11);
+				archetype.Block(c12);
+				archetype.Block(c13);
+				archetype.Block(c14);
+				archetype.Block(c15);
 
 				count += archetype.EntityCount;
 

--- a/Myriad.ECS/Queries/IQuery.cs
+++ b/Myriad.ECS/Queries/IQuery.cs
@@ -210,7 +210,8 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
 
 				count += archetype.EntityCount;
 
@@ -333,7 +334,8 @@ namespace Myriad.ECS.Worlds
 				while (archetypesEnumerator.MoveNext())
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
-					archetype.Block();
+
+					archetype.Block(ComponentID<T0>.ID);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -454,7 +456,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
 
 				count += archetype.EntityCount;
 
@@ -796,7 +798,9 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
 
 				count += archetype.EntityCount;
 
@@ -923,7 +927,9 @@ namespace Myriad.ECS.Worlds
 				while (archetypesEnumerator.MoveNext())
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
-					archetype.Block();
+
+					archetype.Block(ComponentID<T0>.ID);
+					archetype.Block(ComponentID<T1>.ID);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -1049,7 +1055,8 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
 
 				count += archetype.EntityCount;
 
@@ -1413,7 +1420,10 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
 
 				count += archetype.EntityCount;
 
@@ -1544,7 +1554,10 @@ namespace Myriad.ECS.Worlds
 				while (archetypesEnumerator.MoveNext())
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
-					archetype.Block();
+
+					archetype.Block(ComponentID<T0>.ID);
+					archetype.Block(ComponentID<T1>.ID);
+					archetype.Block(ComponentID<T2>.ID);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -1675,7 +1688,9 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
 
 				count += archetype.EntityCount;
 
@@ -2061,7 +2076,11 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
 
 				count += archetype.EntityCount;
 
@@ -2196,7 +2215,11 @@ namespace Myriad.ECS.Worlds
 				while (archetypesEnumerator.MoveNext())
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
-					archetype.Block();
+
+					archetype.Block(ComponentID<T0>.ID);
+					archetype.Block(ComponentID<T1>.ID);
+					archetype.Block(ComponentID<T2>.ID);
+					archetype.Block(ComponentID<T3>.ID);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -2332,7 +2355,10 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
 
 				count += archetype.EntityCount;
 
@@ -2740,7 +2766,12 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
 
 				count += archetype.EntityCount;
 
@@ -2879,7 +2910,12 @@ namespace Myriad.ECS.Worlds
 				while (archetypesEnumerator.MoveNext())
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
-					archetype.Block();
+
+					archetype.Block(ComponentID<T0>.ID);
+					archetype.Block(ComponentID<T1>.ID);
+					archetype.Block(ComponentID<T2>.ID);
+					archetype.Block(ComponentID<T3>.ID);
+					archetype.Block(ComponentID<T4>.ID);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -3020,7 +3056,11 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
 
 				count += archetype.EntityCount;
 
@@ -3450,7 +3490,13 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
 
 				count += archetype.EntityCount;
 
@@ -3593,7 +3639,13 @@ namespace Myriad.ECS.Worlds
 				while (archetypesEnumerator.MoveNext())
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
-					archetype.Block();
+
+					archetype.Block(ComponentID<T0>.ID);
+					archetype.Block(ComponentID<T1>.ID);
+					archetype.Block(ComponentID<T2>.ID);
+					archetype.Block(ComponentID<T3>.ID);
+					archetype.Block(ComponentID<T4>.ID);
+					archetype.Block(ComponentID<T5>.ID);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -3739,7 +3791,12 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
 
 				count += archetype.EntityCount;
 
@@ -4191,7 +4248,14 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
 
 				count += archetype.EntityCount;
 
@@ -4338,7 +4402,14 @@ namespace Myriad.ECS.Worlds
 				while (archetypesEnumerator.MoveNext())
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
-					archetype.Block();
+
+					archetype.Block(ComponentID<T0>.ID);
+					archetype.Block(ComponentID<T1>.ID);
+					archetype.Block(ComponentID<T2>.ID);
+					archetype.Block(ComponentID<T3>.ID);
+					archetype.Block(ComponentID<T4>.ID);
+					archetype.Block(ComponentID<T5>.ID);
+					archetype.Block(ComponentID<T6>.ID);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -4489,7 +4560,13 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
 
 				count += archetype.EntityCount;
 
@@ -4963,7 +5040,15 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
 
 				count += archetype.EntityCount;
 
@@ -5114,7 +5199,15 @@ namespace Myriad.ECS.Worlds
 				while (archetypesEnumerator.MoveNext())
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
-					archetype.Block();
+
+					archetype.Block(ComponentID<T0>.ID);
+					archetype.Block(ComponentID<T1>.ID);
+					archetype.Block(ComponentID<T2>.ID);
+					archetype.Block(ComponentID<T3>.ID);
+					archetype.Block(ComponentID<T4>.ID);
+					archetype.Block(ComponentID<T5>.ID);
+					archetype.Block(ComponentID<T6>.ID);
+					archetype.Block(ComponentID<T7>.ID);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -5270,7 +5363,14 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
 
 				count += archetype.EntityCount;
 
@@ -5766,7 +5866,16 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
 
 				count += archetype.EntityCount;
 
@@ -5921,7 +6030,16 @@ namespace Myriad.ECS.Worlds
 				while (archetypesEnumerator.MoveNext())
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
-					archetype.Block();
+
+					archetype.Block(ComponentID<T0>.ID);
+					archetype.Block(ComponentID<T1>.ID);
+					archetype.Block(ComponentID<T2>.ID);
+					archetype.Block(ComponentID<T3>.ID);
+					archetype.Block(ComponentID<T4>.ID);
+					archetype.Block(ComponentID<T5>.ID);
+					archetype.Block(ComponentID<T6>.ID);
+					archetype.Block(ComponentID<T7>.ID);
+					archetype.Block(ComponentID<T8>.ID);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -6082,7 +6200,15 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
 
 				count += archetype.EntityCount;
 
@@ -6600,7 +6726,17 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
 
 				count += archetype.EntityCount;
 
@@ -6759,7 +6895,17 @@ namespace Myriad.ECS.Worlds
 				while (archetypesEnumerator.MoveNext())
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
-					archetype.Block();
+
+					archetype.Block(ComponentID<T0>.ID);
+					archetype.Block(ComponentID<T1>.ID);
+					archetype.Block(ComponentID<T2>.ID);
+					archetype.Block(ComponentID<T3>.ID);
+					archetype.Block(ComponentID<T4>.ID);
+					archetype.Block(ComponentID<T5>.ID);
+					archetype.Block(ComponentID<T6>.ID);
+					archetype.Block(ComponentID<T7>.ID);
+					archetype.Block(ComponentID<T8>.ID);
+					archetype.Block(ComponentID<T9>.ID);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -6925,7 +7071,16 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
 
 				count += archetype.EntityCount;
 
@@ -7465,7 +7620,18 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
 
 				count += archetype.EntityCount;
 
@@ -7628,7 +7794,18 @@ namespace Myriad.ECS.Worlds
 				while (archetypesEnumerator.MoveNext())
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
-					archetype.Block();
+
+					archetype.Block(ComponentID<T0>.ID);
+					archetype.Block(ComponentID<T1>.ID);
+					archetype.Block(ComponentID<T2>.ID);
+					archetype.Block(ComponentID<T3>.ID);
+					archetype.Block(ComponentID<T4>.ID);
+					archetype.Block(ComponentID<T5>.ID);
+					archetype.Block(ComponentID<T6>.ID);
+					archetype.Block(ComponentID<T7>.ID);
+					archetype.Block(ComponentID<T8>.ID);
+					archetype.Block(ComponentID<T9>.ID);
+					archetype.Block(ComponentID<T10>.ID);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -7799,7 +7976,17 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
 
 				count += archetype.EntityCount;
 
@@ -8361,7 +8548,19 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
 
 				count += archetype.EntityCount;
 
@@ -8528,7 +8727,19 @@ namespace Myriad.ECS.Worlds
 				while (archetypesEnumerator.MoveNext())
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
-					archetype.Block();
+
+					archetype.Block(ComponentID<T0>.ID);
+					archetype.Block(ComponentID<T1>.ID);
+					archetype.Block(ComponentID<T2>.ID);
+					archetype.Block(ComponentID<T3>.ID);
+					archetype.Block(ComponentID<T4>.ID);
+					archetype.Block(ComponentID<T5>.ID);
+					archetype.Block(ComponentID<T6>.ID);
+					archetype.Block(ComponentID<T7>.ID);
+					archetype.Block(ComponentID<T8>.ID);
+					archetype.Block(ComponentID<T9>.ID);
+					archetype.Block(ComponentID<T10>.ID);
+					archetype.Block(ComponentID<T11>.ID);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -8704,7 +8915,18 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
 
 				count += archetype.EntityCount;
 
@@ -9288,7 +9510,20 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
 
 				count += archetype.EntityCount;
 
@@ -9459,7 +9694,20 @@ namespace Myriad.ECS.Worlds
 				while (archetypesEnumerator.MoveNext())
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
-					archetype.Block();
+
+					archetype.Block(ComponentID<T0>.ID);
+					archetype.Block(ComponentID<T1>.ID);
+					archetype.Block(ComponentID<T2>.ID);
+					archetype.Block(ComponentID<T3>.ID);
+					archetype.Block(ComponentID<T4>.ID);
+					archetype.Block(ComponentID<T5>.ID);
+					archetype.Block(ComponentID<T6>.ID);
+					archetype.Block(ComponentID<T7>.ID);
+					archetype.Block(ComponentID<T8>.ID);
+					archetype.Block(ComponentID<T9>.ID);
+					archetype.Block(ComponentID<T10>.ID);
+					archetype.Block(ComponentID<T11>.ID);
+					archetype.Block(ComponentID<T12>.ID);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -9640,7 +9888,19 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
 
 				count += archetype.EntityCount;
 
@@ -10246,7 +10506,21 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(ComponentID<T13>.ID);
 
 				count += archetype.EntityCount;
 
@@ -10421,7 +10695,21 @@ namespace Myriad.ECS.Worlds
 				while (archetypesEnumerator.MoveNext())
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
-					archetype.Block();
+
+					archetype.Block(ComponentID<T0>.ID);
+					archetype.Block(ComponentID<T1>.ID);
+					archetype.Block(ComponentID<T2>.ID);
+					archetype.Block(ComponentID<T3>.ID);
+					archetype.Block(ComponentID<T4>.ID);
+					archetype.Block(ComponentID<T5>.ID);
+					archetype.Block(ComponentID<T6>.ID);
+					archetype.Block(ComponentID<T7>.ID);
+					archetype.Block(ComponentID<T8>.ID);
+					archetype.Block(ComponentID<T9>.ID);
+					archetype.Block(ComponentID<T10>.ID);
+					archetype.Block(ComponentID<T11>.ID);
+					archetype.Block(ComponentID<T12>.ID);
+					archetype.Block(ComponentID<T13>.ID);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -10607,7 +10895,20 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(ComponentID<T13>.ID);
 
 				count += archetype.EntityCount;
 
@@ -11235,7 +11536,22 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(ComponentID<T13>.ID);
+				archetype.Block(ComponentID<T14>.ID);
 
 				count += archetype.EntityCount;
 
@@ -11414,7 +11730,22 @@ namespace Myriad.ECS.Worlds
 				while (archetypesEnumerator.MoveNext())
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
-					archetype.Block();
+
+					archetype.Block(ComponentID<T0>.ID);
+					archetype.Block(ComponentID<T1>.ID);
+					archetype.Block(ComponentID<T2>.ID);
+					archetype.Block(ComponentID<T3>.ID);
+					archetype.Block(ComponentID<T4>.ID);
+					archetype.Block(ComponentID<T5>.ID);
+					archetype.Block(ComponentID<T6>.ID);
+					archetype.Block(ComponentID<T7>.ID);
+					archetype.Block(ComponentID<T8>.ID);
+					archetype.Block(ComponentID<T9>.ID);
+					archetype.Block(ComponentID<T10>.ID);
+					archetype.Block(ComponentID<T11>.ID);
+					archetype.Block(ComponentID<T12>.ID);
+					archetype.Block(ComponentID<T13>.ID);
+					archetype.Block(ComponentID<T14>.ID);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -11605,7 +11936,21 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(ComponentID<T13>.ID);
+				archetype.Block(ComponentID<T14>.ID);
 
 				count += archetype.EntityCount;
 
@@ -12255,7 +12600,23 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(ComponentID<T13>.ID);
+				archetype.Block(ComponentID<T14>.ID);
+				archetype.Block(ComponentID<T15>.ID);
 
 				count += archetype.EntityCount;
 
@@ -12438,7 +12799,23 @@ namespace Myriad.ECS.Worlds
 				while (archetypesEnumerator.MoveNext())
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
-					archetype.Block();
+
+					archetype.Block(ComponentID<T0>.ID);
+					archetype.Block(ComponentID<T1>.ID);
+					archetype.Block(ComponentID<T2>.ID);
+					archetype.Block(ComponentID<T3>.ID);
+					archetype.Block(ComponentID<T4>.ID);
+					archetype.Block(ComponentID<T5>.ID);
+					archetype.Block(ComponentID<T6>.ID);
+					archetype.Block(ComponentID<T7>.ID);
+					archetype.Block(ComponentID<T8>.ID);
+					archetype.Block(ComponentID<T9>.ID);
+					archetype.Block(ComponentID<T10>.ID);
+					archetype.Block(ComponentID<T11>.ID);
+					archetype.Block(ComponentID<T12>.ID);
+					archetype.Block(ComponentID<T13>.ID);
+					archetype.Block(ComponentID<T14>.ID);
+					archetype.Block(ComponentID<T15>.ID);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -12634,7 +13011,22 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(ComponentID<T13>.ID);
+				archetype.Block(ComponentID<T14>.ID);
+				archetype.Block(ComponentID<T15>.ID);
 
 				count += archetype.EntityCount;
 

--- a/Myriad.ECS/Queries/IQuery.tt
+++ b/Myriad.ECS/Queries/IQuery.tt
@@ -230,7 +230,7 @@ namespace Myriad.ECS.Worlds
 <# for (var k = 0; k < i; k++)
 {
 #>
-				archetype.Block(ComponentID<T<#= k #>>.ID);
+				archetype.Block(c<#= k #>);
 <#
 }
 #>

--- a/Myriad.ECS/Queries/IQuery.tt
+++ b/Myriad.ECS/Queries/IQuery.tt
@@ -223,7 +223,17 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
+
+<# if (i == 0) { #>
 				archetype.Block();
+<# } #>
+<# for (var k = 0; k < i; k++)
+{
+#>
+				archetype.Block(ComponentID<T<#= k #>>.ID);
+<#
+}
+#>
 
 				count += archetype.EntityCount;
 
@@ -349,7 +359,17 @@ namespace Myriad.ECS.Worlds
 				while (archetypesEnumerator.MoveNext())
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
-					archetype.Block();
+
+<# if (i == 0) { #>
+				archetype.Block();
+<# } #>
+<# for (var k = 0; k < i; k++)
+{
+#>
+					archetype.Block(ComponentID<T<#= k #>>.ID);
+<#
+}
+#>
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -458,7 +478,16 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
+<# if (i == 0) { #>
 				archetype.Block();
+<# } #>
+<# for (var k = 0; k < i; k++)
+{
+#>
+				archetype.Block(ComponentID<T<#= k #>>.ID);
+<#
+}
+#>
 
 				count += archetype.EntityCount;
 

--- a/Myriad.ECS/Queries/IVectorChunkQuery.cs
+++ b/Myriad.ECS/Queries/IVectorChunkQuery.cs
@@ -70,7 +70,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -195,7 +195,8 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -338,7 +339,9 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -499,7 +502,10 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -678,7 +684,11 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -875,7 +885,12 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -1090,7 +1105,13 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -1323,7 +1344,14 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -1574,7 +1602,15 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -1843,7 +1879,16 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -2130,7 +2175,17 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -2435,7 +2490,18 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -2758,7 +2824,19 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -3099,7 +3177,20 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(ComponentID<T13>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -3458,7 +3549,21 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(ComponentID<T13>.ID);
+				archetype.Block(ComponentID<T14>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -3835,7 +3940,22 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block();
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(ComponentID<T13>.ID);
+				archetype.Block(ComponentID<T14>.ID);
+				archetype.Block(ComponentID<T15>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)

--- a/Myriad.ECS/Queries/IVectorChunkQuery.tt
+++ b/Myriad.ECS/Queries/IVectorChunkQuery.tt
@@ -104,7 +104,16 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
+<# if (sumij == 0) { #>
 				archetype.Block();
+<# } #>
+<# for (var k = 0; k < sumij; k++)
+{
+#>
+				archetype.Block(ComponentID<T<#= k #>>.ID);
+<#
+}
+#>
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)

--- a/Myriad.ECS/Queries/QueryDescription.cs
+++ b/Myriad.ECS/Queries/QueryDescription.cs
@@ -624,7 +624,7 @@ public sealed class QueryDescription
 
             count += match.Archetype.EntityCount;
 
-            // Wait for multithreaded access to this archetype
+            // Wait for multithreaded access to this component in this archetype
             match.Archetype.Block(id);
 
             using var chunks = match.Archetype.GetChunkEnumerator();

--- a/Myriad.ECS/Queries/QueryDescription.cs
+++ b/Myriad.ECS/Queries/QueryDescription.cs
@@ -625,7 +625,7 @@ public sealed class QueryDescription
             count += match.Archetype.EntityCount;
 
             // Wait for multithreaded access to this archetype
-            match.Archetype.Block();
+            match.Archetype.Block(id);
 
             using var chunks = match.Archetype.GetChunkEnumerator();
             while (chunks.MoveNext())

--- a/Myriad.ECS/Queries/QueryEnumerable.cs
+++ b/Myriad.ECS/Queries/QueryEnumerable.cs
@@ -76,7 +76,8 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
-                _archetypesEnumerator.Current.Archetype.Block();
+                var archetype = _archetypesEnumerator.Current.Archetype;
+				archetype.Block();
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -208,7 +209,8 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
-                _archetypesEnumerator.Current.Archetype.Block();
+                var archetype = _archetypesEnumerator.Current.Archetype;
+				archetype.Block(ComponentID<T0>.ID);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -359,7 +361,9 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
-                _archetypesEnumerator.Current.Archetype.Block();
+                var archetype = _archetypesEnumerator.Current.Archetype;
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -519,7 +523,10 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
-                _archetypesEnumerator.Current.Archetype.Block();
+                var archetype = _archetypesEnumerator.Current.Archetype;
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -688,7 +695,11 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
-                _archetypesEnumerator.Current.Archetype.Block();
+                var archetype = _archetypesEnumerator.Current.Archetype;
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -866,7 +877,12 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
-                _archetypesEnumerator.Current.Archetype.Block();
+                var archetype = _archetypesEnumerator.Current.Archetype;
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -1053,7 +1069,13 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
-                _archetypesEnumerator.Current.Archetype.Block();
+                var archetype = _archetypesEnumerator.Current.Archetype;
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -1249,7 +1271,14 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
-                _archetypesEnumerator.Current.Archetype.Block();
+                var archetype = _archetypesEnumerator.Current.Archetype;
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -1454,7 +1483,15 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
-                _archetypesEnumerator.Current.Archetype.Block();
+                var archetype = _archetypesEnumerator.Current.Archetype;
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -1668,7 +1705,16 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
-                _archetypesEnumerator.Current.Archetype.Block();
+                var archetype = _archetypesEnumerator.Current.Archetype;
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -1891,7 +1937,17 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
-                _archetypesEnumerator.Current.Archetype.Block();
+                var archetype = _archetypesEnumerator.Current.Archetype;
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -2123,7 +2179,18 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
-                _archetypesEnumerator.Current.Archetype.Block();
+                var archetype = _archetypesEnumerator.Current.Archetype;
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -2364,7 +2431,19 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
-                _archetypesEnumerator.Current.Archetype.Block();
+                var archetype = _archetypesEnumerator.Current.Archetype;
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -2614,7 +2693,20 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
-                _archetypesEnumerator.Current.Archetype.Block();
+                var archetype = _archetypesEnumerator.Current.Archetype;
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -2873,7 +2965,21 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
-                _archetypesEnumerator.Current.Archetype.Block();
+                var archetype = _archetypesEnumerator.Current.Archetype;
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(ComponentID<T13>.ID);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -3141,7 +3247,22 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
-                _archetypesEnumerator.Current.Archetype.Block();
+                var archetype = _archetypesEnumerator.Current.Archetype;
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(ComponentID<T13>.ID);
+				archetype.Block(ComponentID<T14>.ID);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -3418,7 +3539,23 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
-                _archetypesEnumerator.Current.Archetype.Block();
+                var archetype = _archetypesEnumerator.Current.Archetype;
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(ComponentID<T13>.ID);
+				archetype.Block(ComponentID<T14>.ID);
+				archetype.Block(ComponentID<T15>.ID);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.

--- a/Myriad.ECS/Queries/QueryEnumerable.cs
+++ b/Myriad.ECS/Queries/QueryEnumerable.cs
@@ -210,7 +210,7 @@ namespace Myriad.ECS.Queries
                     return false;
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(C0);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -362,8 +362,8 @@ namespace Myriad.ECS.Queries
                     return false;
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(C0);
+				archetype.Block(C1);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -524,9 +524,9 @@ namespace Myriad.ECS.Queries
                     return false;
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(C0);
+				archetype.Block(C1);
+				archetype.Block(C2);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -696,10 +696,10 @@ namespace Myriad.ECS.Queries
                     return false;
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(C0);
+				archetype.Block(C1);
+				archetype.Block(C2);
+				archetype.Block(C3);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -878,11 +878,11 @@ namespace Myriad.ECS.Queries
                     return false;
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(C0);
+				archetype.Block(C1);
+				archetype.Block(C2);
+				archetype.Block(C3);
+				archetype.Block(C4);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -1070,12 +1070,12 @@ namespace Myriad.ECS.Queries
                     return false;
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(C0);
+				archetype.Block(C1);
+				archetype.Block(C2);
+				archetype.Block(C3);
+				archetype.Block(C4);
+				archetype.Block(C5);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -1272,13 +1272,13 @@ namespace Myriad.ECS.Queries
                     return false;
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(C0);
+				archetype.Block(C1);
+				archetype.Block(C2);
+				archetype.Block(C3);
+				archetype.Block(C4);
+				archetype.Block(C5);
+				archetype.Block(C6);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -1484,14 +1484,14 @@ namespace Myriad.ECS.Queries
                     return false;
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(C0);
+				archetype.Block(C1);
+				archetype.Block(C2);
+				archetype.Block(C3);
+				archetype.Block(C4);
+				archetype.Block(C5);
+				archetype.Block(C6);
+				archetype.Block(C7);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -1706,15 +1706,15 @@ namespace Myriad.ECS.Queries
                     return false;
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(C0);
+				archetype.Block(C1);
+				archetype.Block(C2);
+				archetype.Block(C3);
+				archetype.Block(C4);
+				archetype.Block(C5);
+				archetype.Block(C6);
+				archetype.Block(C7);
+				archetype.Block(C8);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -1938,16 +1938,16 @@ namespace Myriad.ECS.Queries
                     return false;
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(C0);
+				archetype.Block(C1);
+				archetype.Block(C2);
+				archetype.Block(C3);
+				archetype.Block(C4);
+				archetype.Block(C5);
+				archetype.Block(C6);
+				archetype.Block(C7);
+				archetype.Block(C8);
+				archetype.Block(C9);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -2180,17 +2180,17 @@ namespace Myriad.ECS.Queries
                     return false;
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(C0);
+				archetype.Block(C1);
+				archetype.Block(C2);
+				archetype.Block(C3);
+				archetype.Block(C4);
+				archetype.Block(C5);
+				archetype.Block(C6);
+				archetype.Block(C7);
+				archetype.Block(C8);
+				archetype.Block(C9);
+				archetype.Block(C10);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -2432,18 +2432,18 @@ namespace Myriad.ECS.Queries
                     return false;
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(C0);
+				archetype.Block(C1);
+				archetype.Block(C2);
+				archetype.Block(C3);
+				archetype.Block(C4);
+				archetype.Block(C5);
+				archetype.Block(C6);
+				archetype.Block(C7);
+				archetype.Block(C8);
+				archetype.Block(C9);
+				archetype.Block(C10);
+				archetype.Block(C11);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -2694,19 +2694,19 @@ namespace Myriad.ECS.Queries
                     return false;
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(C0);
+				archetype.Block(C1);
+				archetype.Block(C2);
+				archetype.Block(C3);
+				archetype.Block(C4);
+				archetype.Block(C5);
+				archetype.Block(C6);
+				archetype.Block(C7);
+				archetype.Block(C8);
+				archetype.Block(C9);
+				archetype.Block(C10);
+				archetype.Block(C11);
+				archetype.Block(C12);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -2966,20 +2966,20 @@ namespace Myriad.ECS.Queries
                     return false;
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
-				archetype.Block(ComponentID<T13>.ID);
+				archetype.Block(C0);
+				archetype.Block(C1);
+				archetype.Block(C2);
+				archetype.Block(C3);
+				archetype.Block(C4);
+				archetype.Block(C5);
+				archetype.Block(C6);
+				archetype.Block(C7);
+				archetype.Block(C8);
+				archetype.Block(C9);
+				archetype.Block(C10);
+				archetype.Block(C11);
+				archetype.Block(C12);
+				archetype.Block(C13);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -3248,21 +3248,21 @@ namespace Myriad.ECS.Queries
                     return false;
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
-				archetype.Block(ComponentID<T13>.ID);
-				archetype.Block(ComponentID<T14>.ID);
+				archetype.Block(C0);
+				archetype.Block(C1);
+				archetype.Block(C2);
+				archetype.Block(C3);
+				archetype.Block(C4);
+				archetype.Block(C5);
+				archetype.Block(C6);
+				archetype.Block(C7);
+				archetype.Block(C8);
+				archetype.Block(C9);
+				archetype.Block(C10);
+				archetype.Block(C11);
+				archetype.Block(C12);
+				archetype.Block(C13);
+				archetype.Block(C14);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -3540,22 +3540,22 @@ namespace Myriad.ECS.Queries
                     return false;
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
-				archetype.Block(ComponentID<T13>.ID);
-				archetype.Block(ComponentID<T14>.ID);
-				archetype.Block(ComponentID<T15>.ID);
+				archetype.Block(C0);
+				archetype.Block(C1);
+				archetype.Block(C2);
+				archetype.Block(C3);
+				archetype.Block(C4);
+				archetype.Block(C5);
+				archetype.Block(C6);
+				archetype.Block(C7);
+				archetype.Block(C8);
+				archetype.Block(C9);
+				archetype.Block(C10);
+				archetype.Block(C11);
+				archetype.Block(C12);
+				archetype.Block(C13);
+				archetype.Block(C14);
+				archetype.Block(C15);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.

--- a/Myriad.ECS/Queries/QueryEnumerable.tt
+++ b/Myriad.ECS/Queries/QueryEnumerable.tt
@@ -157,7 +157,17 @@ for (var k = 0; k < i; k++)
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
-                _archetypesEnumerator.Current.Archetype.Block();
+                var archetype = _archetypesEnumerator.Current.Archetype;
+<# if (i == 0) { #>
+				archetype.Block();
+<# } #>
+<# for (var k = 0; k < i; k++)
+{
+#>
+				archetype.Block(ComponentID<T<#= k #>>.ID);
+<#
+}
+#>
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.

--- a/Myriad.ECS/Queries/QueryEnumerable.tt
+++ b/Myriad.ECS/Queries/QueryEnumerable.tt
@@ -164,7 +164,7 @@ for (var k = 0; k < i; k++)
 <# for (var k = 0; k < i; k++)
 {
 #>
-				archetype.Block(ComponentID<T<#= k #>>.ID);
+				archetype.Block(C<#= k #>);
 <#
 }
 #>

--- a/Myriad.ECS/Queries/QueryMapReduce.cs
+++ b/Myriad.ECS/Queries/QueryMapReduce.cs
@@ -259,7 +259,8 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -524,7 +525,9 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -803,7 +806,10 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -1096,7 +1102,11 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -1403,7 +1413,12 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -1724,7 +1739,13 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -2059,7 +2080,14 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -2408,7 +2436,15 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -2771,7 +2807,16 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -3148,7 +3193,17 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -3539,7 +3594,18 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -3944,7 +4010,19 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -4363,7 +4441,20 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -4796,7 +4887,21 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(ComponentID<T13>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -5243,7 +5348,22 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(ComponentID<T13>.ID);
+				archetype.Block(ComponentID<T14>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -5704,7 +5824,23 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
-				archetype.Block();
+
+				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(ComponentID<T13>.ID);
+				archetype.Block(ComponentID<T14>.ID);
+				archetype.Block(ComponentID<T15>.ID);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)

--- a/Myriad.ECS/Queries/QueryMapReduce.tt
+++ b/Myriad.ECS/Queries/QueryMapReduce.tt
@@ -285,7 +285,17 @@ namespace Myriad.ECS.Worlds
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
+
+<# if (i == 0) { #>
 				archetype.Block();
+<# } #>
+<# for (var k = 0; k < sumij; k++)
+{
+#>
+				archetype.Block(ComponentID<T<#= k #>>.ID);
+<#
+}
+#>
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)

--- a/Myriad.ECS/Worlds/Archetypes/Archetype.cs
+++ b/Myriad.ECS/Worlds/Archetypes/Archetype.cs
@@ -392,4 +392,12 @@ public sealed partial class Archetype
     {
         World.LockManager.Block(this);
     }
+
+    /// <summary>
+    /// Block on multithreaded access to the given component in this archetype to finish
+    /// </summary>
+    public void Block(ComponentID id)
+    {
+        World.LockManager.Block(this, id);
+    }
 }

--- a/Myriad.ECS/Worlds/Chunks/Chunk.cs
+++ b/Myriad.ECS/Worlds/Chunks/Chunk.cs
@@ -23,6 +23,7 @@ internal sealed partial class Chunk
     private readonly ReadOnlyMemory<ComponentID> _componentIdLookup;
 
     private readonly Entity[] _entities;
+    private readonly EntityId[] _entityIds;
     private readonly Array[] _components;
 
     private uint[]? _bits;
@@ -37,6 +38,11 @@ internal sealed partial class Chunk
     /// </summary>
     public ReadOnlyMemory<Entity> Entities => _entities.AsMemory(0, EntityCount);
 
+    /// <summary>
+    /// Get all of the entities in this chunk
+    /// </summary>
+    public ReadOnlyMemory<EntityId> EntityIds => _entityIds.AsMemory(0, EntityCount);
+
     private static long _nextId;
     /// <summary>
     /// Globally Unique ID for this chunk
@@ -50,6 +56,7 @@ internal sealed partial class Chunk
         Archetype = archetype;
         _componentIndexLookup = componentIndexLookup;
         _entities = new Entity[size];
+        _entityIds = new EntityId[size];
         _componentIdLookup = ids;
 
         _components = new Array[componentTypes.Length];
@@ -71,6 +78,7 @@ internal sealed partial class Chunk
         where T : IComponent
     {
         Debug.Assert(_entities[rowIndex].ID == entityId, "Mismatched entities in chunk");
+        Debug.Assert(_entityIds[rowIndex] == entityId, "Mismatched entities in chunk");
         return ref GetRef<T>(rowIndex);
     }
 
@@ -79,6 +87,7 @@ internal sealed partial class Chunk
         where T : IComponent
     {
         Debug.Assert(_entities[rowIndex].ID == entityId, "Mismatched entities in chunk");
+        Debug.Assert(_entityIds[rowIndex] == entityId, "Mismatched entities in chunk");
 
 #if NET6_0_OR_GREATER
         return new RefT<T>(ref GetRef<T>(rowIndex));
@@ -218,6 +227,7 @@ internal sealed partial class Chunk
         // Clean up all the IDs so they're default instead of some invalid value. This is
         // necessary in case anything is holding on to a reference to the chunk.
         Array.Clear(_entities, 0, _entities.Length);
+        Array.Clear(_entityIds, 0, _entityIds.Length);
 
         EntityCount = 0;
     }
@@ -234,6 +244,7 @@ internal sealed partial class Chunk
 
         // Occupy this row
         _entities[index] = entity.ToEntity(Archetype.World);
+        _entityIds[index] = entity;
 
         // Update global entity info to refer to this location
         info.RowIndex = index;
@@ -256,6 +267,7 @@ internal sealed partial class Chunk
         if (EntityCount == 0)
         {
             _entities[index] = default;
+            _entityIds[index] = default;
             return;
         }
 
@@ -267,7 +279,9 @@ internal sealed partial class Chunk
             var lastEntityIndex = EntityCount;
             ref var lastInfo = ref Archetype.World.GetEntityInfo(lastEntity.ID);
             _entities[index] = lastEntity;
+            _entityIds[index] = lastEntity.ID;
             _entities[lastEntityIndex] = default;
+            _entityIds[lastEntityIndex] = default;
             lastInfo.RowIndex = index;
 
             // Copy top entity components into place
@@ -322,5 +336,10 @@ internal sealed partial class Chunk
     internal Entity[] GetEntityArray()
     {
         return _entities;
+    }
+
+    internal EntityId[] GetEntityIdArray()
+    {
+        return _entityIds;
     }
 }

--- a/Myriad.ECS/Worlds/World.cs
+++ b/Myriad.ECS/Worlds/World.cs
@@ -58,7 +58,7 @@ public sealed partial class World
     }
 
     /// <summary>
-    /// Call <see cref="Archetype.Block"/> on all archetypes in this world
+    /// Call <see cref="Archetype.Block()"/> on all archetypes in this world
     /// </summary>
     public void Block()
     {


### PR DESCRIPTION
 - Added narrower safety declarations - blocking on a specific component within an archetype
 - Chunk exposed `EntityId` as well as `Entity`

The model for "block" is that the main thread can start new work that accesses components/archetypes in another thread. The main thread calls "Block" before it's about to access anything, which waits on any declared work to finish.