### PR TITLE
Archetype.HasComponent

### DIFF
--- a/Myriad.ECS/Components/Transform.cs
+++ b/Myriad.ECS/Components/Transform.cs
@@ -162,7 +162,7 @@ public class BaseUpdateTransformHierarchySystem<TData, TTransform, TLocalTransfo
         // - No world transform
         if (parentIsDead
          || parentInfo.Chunk.Archetype.IsPhantom
-         || !parentInfo.Chunk.Archetype.Components.Contains(WorldTransformID)
+         || !parentInfo.Chunk.Archetype.HasComponent(WorldTransformID)
         )
         {
             // Parent is dead, just update this entity as if it is the root
@@ -173,7 +173,7 @@ public class BaseUpdateTransformHierarchySystem<TData, TTransform, TLocalTransfo
             // Get reference to world transform for parent (directly accessing on chunk)
             ref var pWorldTrans = ref parentInfo.Chunk.GetRef<TWorldTransform>(parentInfo.RowIndex, WorldTransformID);
 
-            var parentHasLocal = parentInfo.Chunk.Archetype.Components.Contains(LocalTransformID);
+            var parentHasLocal = parentInfo.Chunk.Archetype.HasComponent(LocalTransformID);
             if (parentHasLocal)
             {
                 // Get reference to local transform for parent (directly accessing on chunk)

--- a/Myriad.ECS/Components/TypedEntityReference.cs
+++ b/Myriad.ECS/Components/TypedEntityReference.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using Myriad.ECS.IDs;
 using Myriad.ECS.Collections;
 using Myriad.ECS.Worlds;

--- a/Myriad.ECS/EntityId.cs
+++ b/Myriad.ECS/EntityId.cs
@@ -241,7 +241,7 @@ public readonly partial struct EntityId
             return false;
 
         // Check for component
-        return info.Chunk.Archetype.Components.Contains(ComponentID<T>.ID);
+        return info.Chunk.Archetype.HasComponent<T>();
     }
 
     /// <summary>
@@ -290,7 +290,7 @@ public readonly partial struct EntityId
         }
 
         // Check if component is in the components set
-        var hasComponents = entityInfo.Chunk.Archetype.Components.Contains(ComponentID<T0>.ID);
+        var hasComponents = entityInfo.Chunk.Archetype.HasComponent<T0>();
         if (!hasComponents)
         {
             output = default;

--- a/Myriad.ECS/Paths/Path.cs
+++ b/Myriad.ECS/Paths/Path.cs
@@ -82,7 +82,7 @@ public readonly partial struct Path
                 return false;
 
             // Check if component is present
-            if (!entityInfo.Chunk.Archetype.Components.Contains(C))
+            if (!entityInfo.Chunk.Archetype.HasComponent(C))
                 return false;
 
             // Follow link

--- a/Myriad.ECS/Paths/RelationalPath.cs
+++ b/Myriad.ECS/Paths/RelationalPath.cs
@@ -41,7 +41,7 @@ public readonly struct Path<T0>
             return false;
 
         // Check if the component is present
-        if (!entityInfo.Chunk.Archetype.Components.Contains(ComponentID<T>.ID))
+        if (!entityInfo.Chunk.Archetype.HasComponent(ComponentID<T>.ID))
             return false;
 
         // Follow link
@@ -88,7 +88,7 @@ public readonly struct Path<T0, T1>
             return false;
 
         // Check if the component is present
-        if (!entityInfo.Chunk.Archetype.Components.Contains(ComponentID<T>.ID))
+        if (!entityInfo.Chunk.Archetype.HasComponent(ComponentID<T>.ID))
             return false;
 
         // Follow link
@@ -139,7 +139,7 @@ public readonly struct Path<T0, T1, T2>
             return false;
 
         // Check if the component is present
-        if (!entityInfo.Chunk.Archetype.Components.Contains(ComponentID<T>.ID))
+        if (!entityInfo.Chunk.Archetype.HasComponent(ComponentID<T>.ID))
             return false;
 
         // Follow link
@@ -194,7 +194,7 @@ public readonly struct Path<T0, T1, T2, T3>
             return false;
 
         // Check if the component is present
-        if (!entityInfo.Chunk.Archetype.Components.Contains(ComponentID<T>.ID))
+        if (!entityInfo.Chunk.Archetype.HasComponent(ComponentID<T>.ID))
             return false;
 
         // Follow link
@@ -253,7 +253,7 @@ public readonly struct Path<T0, T1, T2, T3, T4>
             return false;
 
         // Check if the component is present
-        if (!entityInfo.Chunk.Archetype.Components.Contains(ComponentID<T>.ID))
+        if (!entityInfo.Chunk.Archetype.HasComponent(ComponentID<T>.ID))
             return false;
 
         // Follow link
@@ -316,7 +316,7 @@ public readonly struct Path<T0, T1, T2, T3, T4, T5>
             return false;
 
         // Check if the component is present
-        if (!entityInfo.Chunk.Archetype.Components.Contains(ComponentID<T>.ID))
+        if (!entityInfo.Chunk.Archetype.HasComponent(ComponentID<T>.ID))
             return false;
 
         // Follow link
@@ -383,7 +383,7 @@ public readonly struct Path<T0, T1, T2, T3, T4, T5, T6>
             return false;
 
         // Check if the component is present
-        if (!entityInfo.Chunk.Archetype.Components.Contains(ComponentID<T>.ID))
+        if (!entityInfo.Chunk.Archetype.HasComponent(ComponentID<T>.ID))
             return false;
 
         // Follow link
@@ -454,7 +454,7 @@ public readonly struct Path<T0, T1, T2, T3, T4, T5, T6, T7>
             return false;
 
         // Check if the component is present
-        if (!entityInfo.Chunk.Archetype.Components.Contains(ComponentID<T>.ID))
+        if (!entityInfo.Chunk.Archetype.HasComponent(ComponentID<T>.ID))
             return false;
 
         // Follow link
@@ -529,7 +529,7 @@ public readonly struct Path<T0, T1, T2, T3, T4, T5, T6, T7, T8>
             return false;
 
         // Check if the component is present
-        if (!entityInfo.Chunk.Archetype.Components.Contains(ComponentID<T>.ID))
+        if (!entityInfo.Chunk.Archetype.HasComponent(ComponentID<T>.ID))
             return false;
 
         // Follow link
@@ -608,7 +608,7 @@ public readonly struct Path<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>
             return false;
 
         // Check if the component is present
-        if (!entityInfo.Chunk.Archetype.Components.Contains(ComponentID<T>.ID))
+        if (!entityInfo.Chunk.Archetype.HasComponent(ComponentID<T>.ID))
             return false;
 
         // Follow link
@@ -691,7 +691,7 @@ public readonly struct Path<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>
             return false;
 
         // Check if the component is present
-        if (!entityInfo.Chunk.Archetype.Components.Contains(ComponentID<T>.ID))
+        if (!entityInfo.Chunk.Archetype.HasComponent(ComponentID<T>.ID))
             return false;
 
         // Follow link
@@ -778,7 +778,7 @@ public readonly struct Path<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>
             return false;
 
         // Check if the component is present
-        if (!entityInfo.Chunk.Archetype.Components.Contains(ComponentID<T>.ID))
+        if (!entityInfo.Chunk.Archetype.HasComponent(ComponentID<T>.ID))
             return false;
 
         // Follow link
@@ -869,7 +869,7 @@ public readonly struct Path<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
             return false;
 
         // Check if the component is present
-        if (!entityInfo.Chunk.Archetype.Components.Contains(ComponentID<T>.ID))
+        if (!entityInfo.Chunk.Archetype.HasComponent(ComponentID<T>.ID))
             return false;
 
         // Follow link
@@ -964,7 +964,7 @@ public readonly struct Path<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
             return false;
 
         // Check if the component is present
-        if (!entityInfo.Chunk.Archetype.Components.Contains(ComponentID<T>.ID))
+        if (!entityInfo.Chunk.Archetype.HasComponent(ComponentID<T>.ID))
             return false;
 
         // Follow link
@@ -1063,7 +1063,7 @@ public readonly struct Path<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
             return false;
 
         // Check if the component is present
-        if (!entityInfo.Chunk.Archetype.Components.Contains(ComponentID<T>.ID))
+        if (!entityInfo.Chunk.Archetype.HasComponent(ComponentID<T>.ID))
             return false;
 
         // Follow link
@@ -1166,7 +1166,7 @@ public readonly struct Path<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
             return false;
 
         // Check if the component is present
-        if (!entityInfo.Chunk.Archetype.Components.Contains(ComponentID<T>.ID))
+        if (!entityInfo.Chunk.Archetype.HasComponent(ComponentID<T>.ID))
             return false;
 
         // Follow link

--- a/Myriad.ECS/Paths/RelationalPath.tt
+++ b/Myriad.ECS/Paths/RelationalPath.tt
@@ -61,7 +61,7 @@ public readonly struct Path<#= tparams #>
             return false;
 
         // Check if the component is present
-        if (!entityInfo.Chunk.Archetype.Components.Contains(ComponentID<T>.ID))
+        if (!entityInfo.Chunk.Archetype.HasComponent(ComponentID<T>.ID))
             return false;
 
         // Follow link

--- a/Myriad.ECS/Queries/ChunkHandle.cs
+++ b/Myriad.ECS/Queries/ChunkHandle.cs
@@ -51,7 +51,7 @@ public readonly ref partial struct ChunkHandle
     /// <returns></returns>
     private bool HasComponent(ComponentID id)
     {
-        return Archetype.Components.Contains(id);
+        return Archetype.HasComponent(id);
     }
 
     /// <summary>

--- a/Myriad.ECS/Queries/QueryDescription.cs
+++ b/Myriad.ECS/Queries/QueryDescription.cs
@@ -619,7 +619,7 @@ public sealed class QueryDescription
         var count = 0;
         foreach (var match in GetArchetypes())
         {
-            if (!match.Archetype.Components.Contains(id))
+            if (!match.Archetype.HasComponent(id))
                 continue;
 
             count += match.Archetype.EntityCount;

--- a/Myriad.ECS/Worlds/Archetypes/Archetype.cs
+++ b/Myriad.ECS/Worlds/Archetypes/Archetype.cs
@@ -409,4 +409,27 @@ public sealed partial class Archetype
     {
         World.LockManager.Block(this, id);
     }
+
+    /// <summary>
+    /// Check if this archetype contains the given component
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public bool HasComponent<T>()
+        where T : IComponent
+    {
+        return HasComponent(ComponentID<T>.ID);
+    }
+
+    /// <summary>
+    /// Check if this archetype contains the given component
+    /// </summary>
+    /// <returns></returns>
+    public bool HasComponent(ComponentID id)
+    {
+        var idx = id.Value;
+        return idx > 0
+            && idx < _componentIndexLookup.Length
+            && _componentIndexLookup[idx] != -1;
+    }
 }


### PR DESCRIPTION
Replaced set `Contains` check with direct array lookup for `Archetype.HasComponent` checks