### PR TITLE
Span Block

### DIFF
--- a/Myriad.ECS.Tests/Queries/ChunkHandleTests.cs
+++ b/Myriad.ECS.Tests/Queries/ChunkHandleTests.cs
@@ -36,6 +36,11 @@ public class ChunkHandleTests
             Assert.IsNotNull(danger.GetEntityArray());
             Assert.IsTrue(danger.GetEntityArray().AsSpan(0, ch.EntityCount).SequenceEqual(ch.Entities.Span));
 
+            CollectionAssert.AreEqual(
+                danger.GetEntityIdArray().AsSpan(0, ch.EntityCount).ToArray(),
+                ch.Entities.ToArray().Select(a => a.ID).ToArray()
+            );
+
             Assert.IsTrue(danger.GetComponentArray<ComponentInt32>().AsSpan(0, ch.EntityCount).SequenceEqual(ci));
         });
     }

--- a/Myriad.ECS/Components/TypedEntityReference.cs
+++ b/Myriad.ECS/Components/TypedEntityReference.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Myriad.ECS.IDs;
 using Myriad.ECS.Collections;
 using Myriad.ECS.Worlds;
@@ -109,7 +110,7 @@ public struct TypedEntityReference<T0>
 
 
             // Check if the entity is still where we last saw it
-            return Chunk.Entities.Span[RowIndex] == entity;
+            return Chunk.EntityIds.Span[RowIndex] == entity;
         }
 
         public bool CheckIsStale(EntityId entity)
@@ -278,7 +279,7 @@ public struct TypedEntityReference<T0, T1>
 
 
             // Check if the entity is still where we last saw it
-            return Chunk.Entities.Span[RowIndex] == entity;
+            return Chunk.EntityIds.Span[RowIndex] == entity;
         }
 
         public bool CheckIsStale(EntityId entity)
@@ -450,7 +451,7 @@ public struct TypedEntityReference<T0, T1, T2>
 
 
             // Check if the entity is still where we last saw it
-            return Chunk.Entities.Span[RowIndex] == entity;
+            return Chunk.EntityIds.Span[RowIndex] == entity;
         }
 
         public bool CheckIsStale(EntityId entity)
@@ -625,7 +626,7 @@ public struct TypedEntityReference<T0, T1, T2, T3>
 
 
             // Check if the entity is still where we last saw it
-            return Chunk.Entities.Span[RowIndex] == entity;
+            return Chunk.EntityIds.Span[RowIndex] == entity;
         }
 
         public bool CheckIsStale(EntityId entity)
@@ -803,7 +804,7 @@ public struct TypedEntityReference<T0, T1, T2, T3, T4>
 
 
             // Check if the entity is still where we last saw it
-            return Chunk.Entities.Span[RowIndex] == entity;
+            return Chunk.EntityIds.Span[RowIndex] == entity;
         }
 
         public bool CheckIsStale(EntityId entity)
@@ -984,7 +985,7 @@ public struct TypedEntityReference<T0, T1, T2, T3, T4, T5>
 
 
             // Check if the entity is still where we last saw it
-            return Chunk.Entities.Span[RowIndex] == entity;
+            return Chunk.EntityIds.Span[RowIndex] == entity;
         }
 
         public bool CheckIsStale(EntityId entity)
@@ -1168,7 +1169,7 @@ public struct TypedEntityReference<T0, T1, T2, T3, T4, T5, T6>
 
 
             // Check if the entity is still where we last saw it
-            return Chunk.Entities.Span[RowIndex] == entity;
+            return Chunk.EntityIds.Span[RowIndex] == entity;
         }
 
         public bool CheckIsStale(EntityId entity)
@@ -1355,7 +1356,7 @@ public struct TypedEntityReference<T0, T1, T2, T3, T4, T5, T6, T7>
 
 
             // Check if the entity is still where we last saw it
-            return Chunk.Entities.Span[RowIndex] == entity;
+            return Chunk.EntityIds.Span[RowIndex] == entity;
         }
 
         public bool CheckIsStale(EntityId entity)
@@ -1545,7 +1546,7 @@ public struct TypedEntityReference<T0, T1, T2, T3, T4, T5, T6, T7, T8>
 
 
             // Check if the entity is still where we last saw it
-            return Chunk.Entities.Span[RowIndex] == entity;
+            return Chunk.EntityIds.Span[RowIndex] == entity;
         }
 
         public bool CheckIsStale(EntityId entity)
@@ -1738,7 +1739,7 @@ public struct TypedEntityReference<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>
 
 
             // Check if the entity is still where we last saw it
-            return Chunk.Entities.Span[RowIndex] == entity;
+            return Chunk.EntityIds.Span[RowIndex] == entity;
         }
 
         public bool CheckIsStale(EntityId entity)
@@ -1934,7 +1935,7 @@ public struct TypedEntityReference<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>
 
 
             // Check if the entity is still where we last saw it
-            return Chunk.Entities.Span[RowIndex] == entity;
+            return Chunk.EntityIds.Span[RowIndex] == entity;
         }
 
         public bool CheckIsStale(EntityId entity)
@@ -2133,7 +2134,7 @@ public struct TypedEntityReference<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, 
 
 
             // Check if the entity is still where we last saw it
-            return Chunk.Entities.Span[RowIndex] == entity;
+            return Chunk.EntityIds.Span[RowIndex] == entity;
         }
 
         public bool CheckIsStale(EntityId entity)
@@ -2335,7 +2336,7 @@ public struct TypedEntityReference<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, 
 
 
             // Check if the entity is still where we last saw it
-            return Chunk.Entities.Span[RowIndex] == entity;
+            return Chunk.EntityIds.Span[RowIndex] == entity;
         }
 
         public bool CheckIsStale(EntityId entity)
@@ -2540,7 +2541,7 @@ public struct TypedEntityReference<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, 
 
 
             // Check if the entity is still where we last saw it
-            return Chunk.Entities.Span[RowIndex] == entity;
+            return Chunk.EntityIds.Span[RowIndex] == entity;
         }
 
         public bool CheckIsStale(EntityId entity)
@@ -2748,7 +2749,7 @@ public struct TypedEntityReference<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, 
 
 
             // Check if the entity is still where we last saw it
-            return Chunk.Entities.Span[RowIndex] == entity;
+            return Chunk.EntityIds.Span[RowIndex] == entity;
         }
 
         public bool CheckIsStale(EntityId entity)
@@ -2959,7 +2960,7 @@ public struct TypedEntityReference<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, 
 
 
             // Check if the entity is still where we last saw it
-            return Chunk.Entities.Span[RowIndex] == entity;
+            return Chunk.EntityIds.Span[RowIndex] == entity;
         }
 
         public bool CheckIsStale(EntityId entity)

--- a/Myriad.ECS/Components/TypedEntityReference.cs
+++ b/Myriad.ECS/Components/TypedEntityReference.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using Myriad.ECS.IDs;
 using Myriad.ECS.Collections;
 using Myriad.ECS.Worlds;

--- a/Myriad.ECS/Components/TypedEntityReference.tt
+++ b/Myriad.ECS/Components/TypedEntityReference.tt
@@ -4,7 +4,6 @@
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Collections.Generic" #>
 <#@ output extension=".cs" #>
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Myriad.ECS.IDs;
 using Myriad.ECS.Collections;

--- a/Myriad.ECS/Components/TypedEntityReference.tt
+++ b/Myriad.ECS/Components/TypedEntityReference.tt
@@ -133,7 +133,7 @@ public struct TypedEntityReference<<#= typeParams #>>
 
 
             // Check if the entity is still where we last saw it
-            return Chunk.Entities.Span[RowIndex] == entity;
+            return Chunk.EntityIds.Span[RowIndex] == entity;
         }
 
         public bool CheckIsStale(EntityId entity)

--- a/Myriad.ECS/EntityId.cs
+++ b/Myriad.ECS/EntityId.cs
@@ -266,7 +266,7 @@ public readonly partial struct EntityId
         where T : IComponent
     {
         ref var entityInfo = ref world.GetEntityInfo(this);
-        entityInfo.Chunk.Archetype.Block(ComponentID<T>.ID);
+        entityInfo.Chunk.Archetype.Block(stackalloc ComponentID[] { ComponentID<T>.ID });
         return entityInfo.Chunk.GetRefT<T>(this, entityInfo.RowIndex);
     }
 
@@ -323,7 +323,7 @@ public readonly partial struct EntityId
             return null;
 
         ref var entityInfo = ref world.GetEntityInfo(this);
-        entityInfo.Chunk.Archetype.Block(id);
+        entityInfo.Chunk.Archetype.Block(stackalloc ComponentID[] { id });
         return entityInfo.Chunk.GetComponentArray(id).GetValue(entityInfo.RowIndex);
     }
 }

--- a/Myriad.ECS/Locks/IWorldArchetypeSafetyManager.cs
+++ b/Myriad.ECS/Locks/IWorldArchetypeSafetyManager.cs
@@ -15,13 +15,6 @@ public interface IWorldArchetypeSafetyManager
     void Block(Archetype archetype);
 
     /// <summary>
-    /// Wait for multithreaded work which is accessing a specific component in a specific archetype to finish
-    /// </summary>
-    /// <param name="archetype"></param>
-    /// <param name="id"></param>
-    void Block(Archetype archetype, ComponentID id);
-
-    /// <summary>
     /// Wait for multithreaded work which is accessing a specific set of components in a specific archetype to finish
     /// </summary>
     /// <param name="archetype"></param>
@@ -37,11 +30,6 @@ public class DefaultWorldArchetypeSafetyManager
 {
     /// <inheritdoc />
     public void Block(Archetype archetype)
-    {
-    }
-
-    /// <inheritdoc />
-    public void Block(Archetype archetype, ComponentID id)
     {
     }
 

--- a/Myriad.ECS/Locks/IWorldArchetypeSafetyManager.cs
+++ b/Myriad.ECS/Locks/IWorldArchetypeSafetyManager.cs
@@ -20,6 +20,13 @@ public interface IWorldArchetypeSafetyManager
     /// <param name="archetype"></param>
     /// <param name="id"></param>
     void Block(Archetype archetype, ComponentID id);
+
+    /// <summary>
+    /// Wait for multithreaded work which is accessing a specific set of components in a specific archetype to finish
+    /// </summary>
+    /// <param name="archetype"></param>
+    /// <param name="ids"></param>
+    void Block(Archetype archetype, ReadOnlySpan<ComponentID> ids);
 }
 
 /// <summary>
@@ -35,6 +42,11 @@ public class DefaultWorldArchetypeSafetyManager
 
     /// <inheritdoc />
     public void Block(Archetype archetype, ComponentID id)
+    {
+    }
+
+    /// <inheritdoc />
+    public void Block(Archetype archetype, ReadOnlySpan<ComponentID> ids)
     {
     }
 }

--- a/Myriad.ECS/Myriad.ECS.csproj
+++ b/Myriad.ECS/Myriad.ECS.csproj
@@ -10,7 +10,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>Myriad.ECS</Title>
     <Authors>Martin Evans</Authors>
-    <Version>47.1.0</Version>
+    <Version>48.0.0</Version>
     <Description>Myriad.ECS is a high performance Entity Component System (ECS).</Description>
     <PackageProjectUrl>https://github.com/martindevans/Myriad.ECS</PackageProjectUrl>
     <RepositoryUrl>https://github.com/martindevans/Myriad.ECS</RepositoryUrl>

--- a/Myriad.ECS/Queries/ChunkHandle.cs
+++ b/Myriad.ECS/Queries/ChunkHandle.cs
@@ -26,6 +26,11 @@ public readonly ref partial struct ChunkHandle
     /// </summary>
     public ReadOnlyMemory<Entity> Entities => _chunk.Entities;
 
+    /// <summary>
+    /// Get the entities in this chunk
+    /// </summary>
+    public ReadOnlyMemory<EntityId> EntityIds => _chunk.EntityIds;
+
     internal ChunkHandle(Chunk chunk)
     {
         _chunk = chunk;

--- a/Myriad.ECS/Queries/IChunkQuery.cs
+++ b/Myriad.ECS/Queries/IChunkQuery.cs
@@ -157,12 +157,17 @@ namespace Myriad.ECS.Worlds
 
 		    var c0 = ComponentID<T0>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -205,6 +210,11 @@ namespace Myriad.ECS.Worlds
 			if (archetypes.Count == 0 || !query.Any())
 				return 0;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				ComponentID<T0>.ID,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -240,7 +250,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -500,13 +510,18 @@ namespace Myriad.ECS.Worlds
 		    var c0 = ComponentID<T0>.ID;
 		    var c1 = ComponentID<T1>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -552,6 +567,12 @@ namespace Myriad.ECS.Worlds
 			if (archetypes.Count == 0 || !query.Any())
 				return 0;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				ComponentID<T0>.ID,
+				ComponentID<T1>.ID,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -587,8 +608,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -864,14 +884,19 @@ namespace Myriad.ECS.Worlds
 		    var c1 = ComponentID<T1>.ID;
 		    var c2 = ComponentID<T2>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -920,6 +945,13 @@ namespace Myriad.ECS.Worlds
 			if (archetypes.Count == 0 || !query.Any())
 				return 0;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				ComponentID<T0>.ID,
+				ComponentID<T1>.ID,
+				ComponentID<T2>.ID,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -955,9 +987,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -1249,15 +1279,20 @@ namespace Myriad.ECS.Worlds
 		    var c2 = ComponentID<T2>.ID;
 		    var c3 = ComponentID<T3>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -1309,6 +1344,14 @@ namespace Myriad.ECS.Worlds
 			if (archetypes.Count == 0 || !query.Any())
 				return 0;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				ComponentID<T0>.ID,
+				ComponentID<T1>.ID,
+				ComponentID<T2>.ID,
+				ComponentID<T3>.ID,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -1344,10 +1387,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -1655,16 +1695,21 @@ namespace Myriad.ECS.Worlds
 		    var c3 = ComponentID<T3>.ID;
 		    var c4 = ComponentID<T4>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -1719,6 +1764,15 @@ namespace Myriad.ECS.Worlds
 			if (archetypes.Count == 0 || !query.Any())
 				return 0;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				ComponentID<T0>.ID,
+				ComponentID<T1>.ID,
+				ComponentID<T2>.ID,
+				ComponentID<T3>.ID,
+				ComponentID<T4>.ID,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -1754,11 +1808,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -2082,17 +2132,22 @@ namespace Myriad.ECS.Worlds
 		    var c4 = ComponentID<T4>.ID;
 		    var c5 = ComponentID<T5>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -2150,6 +2205,16 @@ namespace Myriad.ECS.Worlds
 			if (archetypes.Count == 0 || !query.Any())
 				return 0;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				ComponentID<T0>.ID,
+				ComponentID<T1>.ID,
+				ComponentID<T2>.ID,
+				ComponentID<T3>.ID,
+				ComponentID<T4>.ID,
+				ComponentID<T5>.ID,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -2185,12 +2250,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -2530,18 +2590,23 @@ namespace Myriad.ECS.Worlds
 		    var c5 = ComponentID<T5>.ID;
 		    var c6 = ComponentID<T6>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -2602,6 +2667,17 @@ namespace Myriad.ECS.Worlds
 			if (archetypes.Count == 0 || !query.Any())
 				return 0;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				ComponentID<T0>.ID,
+				ComponentID<T1>.ID,
+				ComponentID<T2>.ID,
+				ComponentID<T3>.ID,
+				ComponentID<T4>.ID,
+				ComponentID<T5>.ID,
+				ComponentID<T6>.ID,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -2637,13 +2713,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -2999,19 +3069,24 @@ namespace Myriad.ECS.Worlds
 		    var c6 = ComponentID<T6>.ID;
 		    var c7 = ComponentID<T7>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -3075,6 +3150,18 @@ namespace Myriad.ECS.Worlds
 			if (archetypes.Count == 0 || !query.Any())
 				return 0;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				ComponentID<T0>.ID,
+				ComponentID<T1>.ID,
+				ComponentID<T2>.ID,
+				ComponentID<T3>.ID,
+				ComponentID<T4>.ID,
+				ComponentID<T5>.ID,
+				ComponentID<T6>.ID,
+				ComponentID<T7>.ID,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -3110,14 +3197,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -3489,20 +3569,25 @@ namespace Myriad.ECS.Worlds
 		    var c7 = ComponentID<T7>.ID;
 		    var c8 = ComponentID<T8>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -3569,6 +3654,19 @@ namespace Myriad.ECS.Worlds
 			if (archetypes.Count == 0 || !query.Any())
 				return 0;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				ComponentID<T0>.ID,
+				ComponentID<T1>.ID,
+				ComponentID<T2>.ID,
+				ComponentID<T3>.ID,
+				ComponentID<T4>.ID,
+				ComponentID<T5>.ID,
+				ComponentID<T6>.ID,
+				ComponentID<T7>.ID,
+				ComponentID<T8>.ID,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -3604,15 +3702,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -4000,21 +4090,26 @@ namespace Myriad.ECS.Worlds
 		    var c8 = ComponentID<T8>.ID;
 		    var c9 = ComponentID<T9>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -4084,6 +4179,20 @@ namespace Myriad.ECS.Worlds
 			if (archetypes.Count == 0 || !query.Any())
 				return 0;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				ComponentID<T0>.ID,
+				ComponentID<T1>.ID,
+				ComponentID<T2>.ID,
+				ComponentID<T3>.ID,
+				ComponentID<T4>.ID,
+				ComponentID<T5>.ID,
+				ComponentID<T6>.ID,
+				ComponentID<T7>.ID,
+				ComponentID<T8>.ID,
+				ComponentID<T9>.ID,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -4119,16 +4228,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -4532,22 +4632,27 @@ namespace Myriad.ECS.Worlds
 		    var c9 = ComponentID<T9>.ID;
 		    var c10 = ComponentID<T10>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -4620,6 +4725,21 @@ namespace Myriad.ECS.Worlds
 			if (archetypes.Count == 0 || !query.Any())
 				return 0;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				ComponentID<T0>.ID,
+				ComponentID<T1>.ID,
+				ComponentID<T2>.ID,
+				ComponentID<T3>.ID,
+				ComponentID<T4>.ID,
+				ComponentID<T5>.ID,
+				ComponentID<T6>.ID,
+				ComponentID<T7>.ID,
+				ComponentID<T8>.ID,
+				ComponentID<T9>.ID,
+				ComponentID<T10>.ID,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -4655,17 +4775,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -5085,23 +5195,28 @@ namespace Myriad.ECS.Worlds
 		    var c10 = ComponentID<T10>.ID;
 		    var c11 = ComponentID<T11>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -5177,6 +5292,22 @@ namespace Myriad.ECS.Worlds
 			if (archetypes.Count == 0 || !query.Any())
 				return 0;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				ComponentID<T0>.ID,
+				ComponentID<T1>.ID,
+				ComponentID<T2>.ID,
+				ComponentID<T3>.ID,
+				ComponentID<T4>.ID,
+				ComponentID<T5>.ID,
+				ComponentID<T6>.ID,
+				ComponentID<T7>.ID,
+				ComponentID<T8>.ID,
+				ComponentID<T9>.ID,
+				ComponentID<T10>.ID,
+				ComponentID<T11>.ID,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -5212,18 +5343,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -5659,24 +5779,29 @@ namespace Myriad.ECS.Worlds
 		    var c11 = ComponentID<T11>.ID;
 		    var c12 = ComponentID<T12>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+				c12,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -5755,6 +5880,23 @@ namespace Myriad.ECS.Worlds
 			if (archetypes.Count == 0 || !query.Any())
 				return 0;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				ComponentID<T0>.ID,
+				ComponentID<T1>.ID,
+				ComponentID<T2>.ID,
+				ComponentID<T3>.ID,
+				ComponentID<T4>.ID,
+				ComponentID<T5>.ID,
+				ComponentID<T6>.ID,
+				ComponentID<T7>.ID,
+				ComponentID<T8>.ID,
+				ComponentID<T9>.ID,
+				ComponentID<T10>.ID,
+				ComponentID<T11>.ID,
+				ComponentID<T12>.ID,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -5790,19 +5932,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -6254,25 +6384,30 @@ namespace Myriad.ECS.Worlds
 		    var c12 = ComponentID<T12>.ID;
 		    var c13 = ComponentID<T13>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+				c12,
+				c13,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
-				archetype.Block(ComponentID<T13>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -6354,6 +6489,24 @@ namespace Myriad.ECS.Worlds
 			if (archetypes.Count == 0 || !query.Any())
 				return 0;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				ComponentID<T0>.ID,
+				ComponentID<T1>.ID,
+				ComponentID<T2>.ID,
+				ComponentID<T3>.ID,
+				ComponentID<T4>.ID,
+				ComponentID<T5>.ID,
+				ComponentID<T6>.ID,
+				ComponentID<T7>.ID,
+				ComponentID<T8>.ID,
+				ComponentID<T9>.ID,
+				ComponentID<T10>.ID,
+				ComponentID<T11>.ID,
+				ComponentID<T12>.ID,
+				ComponentID<T13>.ID,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -6389,20 +6542,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
-				archetype.Block(ComponentID<T13>.ID);
+				archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -6870,26 +7010,31 @@ namespace Myriad.ECS.Worlds
 		    var c13 = ComponentID<T13>.ID;
 		    var c14 = ComponentID<T14>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+				c12,
+				c13,
+				c14,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
-				archetype.Block(ComponentID<T13>.ID);
-				archetype.Block(ComponentID<T14>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -6974,6 +7119,25 @@ namespace Myriad.ECS.Worlds
 			if (archetypes.Count == 0 || !query.Any())
 				return 0;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				ComponentID<T0>.ID,
+				ComponentID<T1>.ID,
+				ComponentID<T2>.ID,
+				ComponentID<T3>.ID,
+				ComponentID<T4>.ID,
+				ComponentID<T5>.ID,
+				ComponentID<T6>.ID,
+				ComponentID<T7>.ID,
+				ComponentID<T8>.ID,
+				ComponentID<T9>.ID,
+				ComponentID<T10>.ID,
+				ComponentID<T11>.ID,
+				ComponentID<T12>.ID,
+				ComponentID<T13>.ID,
+				ComponentID<T14>.ID,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -7009,21 +7173,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
-				archetype.Block(ComponentID<T13>.ID);
-				archetype.Block(ComponentID<T14>.ID);
+				archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -7507,27 +7657,32 @@ namespace Myriad.ECS.Worlds
 		    var c14 = ComponentID<T14>.ID;
 		    var c15 = ComponentID<T15>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+				c12,
+				c13,
+				c14,
+				c15,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
-				archetype.Block(ComponentID<T13>.ID);
-				archetype.Block(ComponentID<T14>.ID);
-				archetype.Block(ComponentID<T15>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -7615,6 +7770,26 @@ namespace Myriad.ECS.Worlds
 			if (archetypes.Count == 0 || !query.Any())
 				return 0;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				ComponentID<T0>.ID,
+				ComponentID<T1>.ID,
+				ComponentID<T2>.ID,
+				ComponentID<T3>.ID,
+				ComponentID<T4>.ID,
+				ComponentID<T5>.ID,
+				ComponentID<T6>.ID,
+				ComponentID<T7>.ID,
+				ComponentID<T8>.ID,
+				ComponentID<T9>.ID,
+				ComponentID<T10>.ID,
+				ComponentID<T11>.ID,
+				ComponentID<T12>.ID,
+				ComponentID<T13>.ID,
+				ComponentID<T14>.ID,
+				ComponentID<T15>.ID,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -7650,22 +7825,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
-				archetype.Block(ComponentID<T13>.ID);
-				archetype.Block(ComponentID<T14>.ID);
-				archetype.Block(ComponentID<T15>.ID);
+				archetype.Block(components);
 
 				count += archetype.EntityCount;
 

--- a/Myriad.ECS/Queries/IChunkQuery.tt
+++ b/Myriad.ECS/Queries/IChunkQuery.tt
@@ -213,6 +213,17 @@ namespace Myriad.ECS.Worlds
 }
 #>
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+<# for (var k = 0; k < i; k++)
+{
+#>
+				c<#= k #>,
+<#
+}
+#>
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
@@ -220,14 +231,9 @@ namespace Myriad.ECS.Worlds
 
 <# if (sumij == 0) { #>
 				archetype.Block();
+<# } else { #>
+				archetype.Block(components);
 <# } #>
-<# for (var k = 0; k < sumij; k++)
-{
-#>
-				archetype.Block(ComponentID<T<#= k #>>.ID);
-<#
-}
-#>
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -282,6 +288,17 @@ namespace Myriad.ECS.Worlds
 			if (archetypes.Count == 0 || !query.Any())
 				return 0;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+<# for (var k = 0; k < i; k++)
+{
+#>
+				ComponentID<T<#= k #>>.ID,
+<#
+}
+#>
+			};
+
 <#
 			EmitParallelWorkLoopSetup(workItemName);
 #>
@@ -295,14 +312,9 @@ namespace Myriad.ECS.Worlds
 
 <# if (sumij == 0) { #>
 				archetype.Block();
+<# } else { #>
+				archetype.Block(components);
 <# } #>
-<# for (var k = 0; k < sumij; k++)
-{
-#>
-				archetype.Block(ComponentID<T<#= k #>>.ID);
-<#
-}
-#>
 
 				count += archetype.EntityCount;
 

--- a/Myriad.ECS/Queries/IQuery.cs
+++ b/Myriad.ECS/Queries/IQuery.cs
@@ -206,12 +206,17 @@ namespace Myriad.ECS.Worlds
 
 			var c0 = ComponentID<T0>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(c0);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -315,6 +320,11 @@ namespace Myriad.ECS.Worlds
 
 			var c0 = ComponentID<T0>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+			};
+
 			var entityCount = 0;
 			var lastCompletedArchetype = default(Archetype);
 
@@ -335,7 +345,7 @@ namespace Myriad.ECS.Worlds
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
 
-					archetype.Block(ComponentID<T0>.ID);
+					archetype.Block(components);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -420,6 +430,11 @@ namespace Myriad.ECS.Worlds
 
 			var c0 = ComponentID<T0>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -456,7 +471,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -794,13 +809,18 @@ namespace Myriad.ECS.Worlds
 			var c0 = ComponentID<T0>.ID;
 			var c1 = ComponentID<T1>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(c0);
-				archetype.Block(c1);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -908,6 +928,12 @@ namespace Myriad.ECS.Worlds
 			var c0 = ComponentID<T0>.ID;
 			var c1 = ComponentID<T1>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+			};
+
 			var entityCount = 0;
 			var lastCompletedArchetype = default(Archetype);
 
@@ -928,8 +954,7 @@ namespace Myriad.ECS.Worlds
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
 
-					archetype.Block(ComponentID<T0>.ID);
-					archetype.Block(ComponentID<T1>.ID);
+					archetype.Block(components);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -1019,6 +1044,12 @@ namespace Myriad.ECS.Worlds
 			var c0 = ComponentID<T0>.ID;
 			var c1 = ComponentID<T1>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -1055,8 +1086,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -1416,14 +1446,19 @@ namespace Myriad.ECS.Worlds
 			var c1 = ComponentID<T1>.ID;
 			var c2 = ComponentID<T2>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(c0);
-				archetype.Block(c1);
-				archetype.Block(c2);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -1535,6 +1570,13 @@ namespace Myriad.ECS.Worlds
 			var c1 = ComponentID<T1>.ID;
 			var c2 = ComponentID<T2>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+			};
+
 			var entityCount = 0;
 			var lastCompletedArchetype = default(Archetype);
 
@@ -1555,9 +1597,7 @@ namespace Myriad.ECS.Worlds
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
 
-					archetype.Block(ComponentID<T0>.ID);
-					archetype.Block(ComponentID<T1>.ID);
-					archetype.Block(ComponentID<T2>.ID);
+					archetype.Block(components);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -1652,6 +1692,13 @@ namespace Myriad.ECS.Worlds
 			var c1 = ComponentID<T1>.ID;
 			var c2 = ComponentID<T2>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -1688,9 +1735,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -2072,15 +2117,20 @@ namespace Myriad.ECS.Worlds
 			var c2 = ComponentID<T2>.ID;
 			var c3 = ComponentID<T3>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(c0);
-				archetype.Block(c1);
-				archetype.Block(c2);
-				archetype.Block(c3);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -2196,6 +2246,14 @@ namespace Myriad.ECS.Worlds
 			var c2 = ComponentID<T2>.ID;
 			var c3 = ComponentID<T3>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+			};
+
 			var entityCount = 0;
 			var lastCompletedArchetype = default(Archetype);
 
@@ -2216,10 +2274,7 @@ namespace Myriad.ECS.Worlds
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
 
-					archetype.Block(ComponentID<T0>.ID);
-					archetype.Block(ComponentID<T1>.ID);
-					archetype.Block(ComponentID<T2>.ID);
-					archetype.Block(ComponentID<T3>.ID);
+					archetype.Block(components);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -2319,6 +2374,14 @@ namespace Myriad.ECS.Worlds
 			var c2 = ComponentID<T2>.ID;
 			var c3 = ComponentID<T3>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -2355,10 +2418,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -2762,16 +2822,21 @@ namespace Myriad.ECS.Worlds
 			var c3 = ComponentID<T3>.ID;
 			var c4 = ComponentID<T4>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(c0);
-				archetype.Block(c1);
-				archetype.Block(c2);
-				archetype.Block(c3);
-				archetype.Block(c4);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -2891,6 +2956,15 @@ namespace Myriad.ECS.Worlds
 			var c3 = ComponentID<T3>.ID;
 			var c4 = ComponentID<T4>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+			};
+
 			var entityCount = 0;
 			var lastCompletedArchetype = default(Archetype);
 
@@ -2911,11 +2985,7 @@ namespace Myriad.ECS.Worlds
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
 
-					archetype.Block(ComponentID<T0>.ID);
-					archetype.Block(ComponentID<T1>.ID);
-					archetype.Block(ComponentID<T2>.ID);
-					archetype.Block(ComponentID<T3>.ID);
-					archetype.Block(ComponentID<T4>.ID);
+					archetype.Block(components);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -3020,6 +3090,15 @@ namespace Myriad.ECS.Worlds
 			var c3 = ComponentID<T3>.ID;
 			var c4 = ComponentID<T4>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -3056,11 +3135,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -3486,17 +3561,22 @@ namespace Myriad.ECS.Worlds
 			var c4 = ComponentID<T4>.ID;
 			var c5 = ComponentID<T5>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(c0);
-				archetype.Block(c1);
-				archetype.Block(c2);
-				archetype.Block(c3);
-				archetype.Block(c4);
-				archetype.Block(c5);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -3620,6 +3700,16 @@ namespace Myriad.ECS.Worlds
 			var c4 = ComponentID<T4>.ID;
 			var c5 = ComponentID<T5>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+			};
+
 			var entityCount = 0;
 			var lastCompletedArchetype = default(Archetype);
 
@@ -3640,12 +3730,7 @@ namespace Myriad.ECS.Worlds
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
 
-					archetype.Block(ComponentID<T0>.ID);
-					archetype.Block(ComponentID<T1>.ID);
-					archetype.Block(ComponentID<T2>.ID);
-					archetype.Block(ComponentID<T3>.ID);
-					archetype.Block(ComponentID<T4>.ID);
-					archetype.Block(ComponentID<T5>.ID);
+					archetype.Block(components);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -3755,6 +3840,16 @@ namespace Myriad.ECS.Worlds
 			var c4 = ComponentID<T4>.ID;
 			var c5 = ComponentID<T5>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -3791,12 +3886,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -4244,18 +4334,23 @@ namespace Myriad.ECS.Worlds
 			var c5 = ComponentID<T5>.ID;
 			var c6 = ComponentID<T6>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(c0);
-				archetype.Block(c1);
-				archetype.Block(c2);
-				archetype.Block(c3);
-				archetype.Block(c4);
-				archetype.Block(c5);
-				archetype.Block(c6);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -4383,6 +4478,17 @@ namespace Myriad.ECS.Worlds
 			var c5 = ComponentID<T5>.ID;
 			var c6 = ComponentID<T6>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+			};
+
 			var entityCount = 0;
 			var lastCompletedArchetype = default(Archetype);
 
@@ -4403,13 +4509,7 @@ namespace Myriad.ECS.Worlds
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
 
-					archetype.Block(ComponentID<T0>.ID);
-					archetype.Block(ComponentID<T1>.ID);
-					archetype.Block(ComponentID<T2>.ID);
-					archetype.Block(ComponentID<T3>.ID);
-					archetype.Block(ComponentID<T4>.ID);
-					archetype.Block(ComponentID<T5>.ID);
-					archetype.Block(ComponentID<T6>.ID);
+					archetype.Block(components);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -4524,6 +4624,17 @@ namespace Myriad.ECS.Worlds
 			var c5 = ComponentID<T5>.ID;
 			var c6 = ComponentID<T6>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -4560,13 +4671,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -5036,19 +5141,24 @@ namespace Myriad.ECS.Worlds
 			var c6 = ComponentID<T6>.ID;
 			var c7 = ComponentID<T7>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(c0);
-				archetype.Block(c1);
-				archetype.Block(c2);
-				archetype.Block(c3);
-				archetype.Block(c4);
-				archetype.Block(c5);
-				archetype.Block(c6);
-				archetype.Block(c7);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -5180,6 +5290,18 @@ namespace Myriad.ECS.Worlds
 			var c6 = ComponentID<T6>.ID;
 			var c7 = ComponentID<T7>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+			};
+
 			var entityCount = 0;
 			var lastCompletedArchetype = default(Archetype);
 
@@ -5200,14 +5322,7 @@ namespace Myriad.ECS.Worlds
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
 
-					archetype.Block(ComponentID<T0>.ID);
-					archetype.Block(ComponentID<T1>.ID);
-					archetype.Block(ComponentID<T2>.ID);
-					archetype.Block(ComponentID<T3>.ID);
-					archetype.Block(ComponentID<T4>.ID);
-					archetype.Block(ComponentID<T5>.ID);
-					archetype.Block(ComponentID<T6>.ID);
-					archetype.Block(ComponentID<T7>.ID);
+					archetype.Block(components);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -5327,6 +5442,18 @@ namespace Myriad.ECS.Worlds
 			var c6 = ComponentID<T6>.ID;
 			var c7 = ComponentID<T7>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -5363,14 +5490,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -5862,20 +5982,25 @@ namespace Myriad.ECS.Worlds
 			var c7 = ComponentID<T7>.ID;
 			var c8 = ComponentID<T8>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(c0);
-				archetype.Block(c1);
-				archetype.Block(c2);
-				archetype.Block(c3);
-				archetype.Block(c4);
-				archetype.Block(c5);
-				archetype.Block(c6);
-				archetype.Block(c7);
-				archetype.Block(c8);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -6011,6 +6136,19 @@ namespace Myriad.ECS.Worlds
 			var c7 = ComponentID<T7>.ID;
 			var c8 = ComponentID<T8>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+			};
+
 			var entityCount = 0;
 			var lastCompletedArchetype = default(Archetype);
 
@@ -6031,15 +6169,7 @@ namespace Myriad.ECS.Worlds
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
 
-					archetype.Block(ComponentID<T0>.ID);
-					archetype.Block(ComponentID<T1>.ID);
-					archetype.Block(ComponentID<T2>.ID);
-					archetype.Block(ComponentID<T3>.ID);
-					archetype.Block(ComponentID<T4>.ID);
-					archetype.Block(ComponentID<T5>.ID);
-					archetype.Block(ComponentID<T6>.ID);
-					archetype.Block(ComponentID<T7>.ID);
-					archetype.Block(ComponentID<T8>.ID);
+					archetype.Block(components);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -6164,6 +6294,19 @@ namespace Myriad.ECS.Worlds
 			var c7 = ComponentID<T7>.ID;
 			var c8 = ComponentID<T8>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -6200,15 +6343,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -6722,21 +6857,26 @@ namespace Myriad.ECS.Worlds
 			var c8 = ComponentID<T8>.ID;
 			var c9 = ComponentID<T9>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(c0);
-				archetype.Block(c1);
-				archetype.Block(c2);
-				archetype.Block(c3);
-				archetype.Block(c4);
-				archetype.Block(c5);
-				archetype.Block(c6);
-				archetype.Block(c7);
-				archetype.Block(c8);
-				archetype.Block(c9);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -6876,6 +7016,20 @@ namespace Myriad.ECS.Worlds
 			var c8 = ComponentID<T8>.ID;
 			var c9 = ComponentID<T9>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+			};
+
 			var entityCount = 0;
 			var lastCompletedArchetype = default(Archetype);
 
@@ -6896,16 +7050,7 @@ namespace Myriad.ECS.Worlds
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
 
-					archetype.Block(ComponentID<T0>.ID);
-					archetype.Block(ComponentID<T1>.ID);
-					archetype.Block(ComponentID<T2>.ID);
-					archetype.Block(ComponentID<T3>.ID);
-					archetype.Block(ComponentID<T4>.ID);
-					archetype.Block(ComponentID<T5>.ID);
-					archetype.Block(ComponentID<T6>.ID);
-					archetype.Block(ComponentID<T7>.ID);
-					archetype.Block(ComponentID<T8>.ID);
-					archetype.Block(ComponentID<T9>.ID);
+					archetype.Block(components);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -7035,6 +7180,20 @@ namespace Myriad.ECS.Worlds
 			var c8 = ComponentID<T8>.ID;
 			var c9 = ComponentID<T9>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -7071,16 +7230,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -7616,22 +7766,27 @@ namespace Myriad.ECS.Worlds
 			var c9 = ComponentID<T9>.ID;
 			var c10 = ComponentID<T10>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(c0);
-				archetype.Block(c1);
-				archetype.Block(c2);
-				archetype.Block(c3);
-				archetype.Block(c4);
-				archetype.Block(c5);
-				archetype.Block(c6);
-				archetype.Block(c7);
-				archetype.Block(c8);
-				archetype.Block(c9);
-				archetype.Block(c10);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -7775,6 +7930,21 @@ namespace Myriad.ECS.Worlds
 			var c9 = ComponentID<T9>.ID;
 			var c10 = ComponentID<T10>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+			};
+
 			var entityCount = 0;
 			var lastCompletedArchetype = default(Archetype);
 
@@ -7795,17 +7965,7 @@ namespace Myriad.ECS.Worlds
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
 
-					archetype.Block(ComponentID<T0>.ID);
-					archetype.Block(ComponentID<T1>.ID);
-					archetype.Block(ComponentID<T2>.ID);
-					archetype.Block(ComponentID<T3>.ID);
-					archetype.Block(ComponentID<T4>.ID);
-					archetype.Block(ComponentID<T5>.ID);
-					archetype.Block(ComponentID<T6>.ID);
-					archetype.Block(ComponentID<T7>.ID);
-					archetype.Block(ComponentID<T8>.ID);
-					archetype.Block(ComponentID<T9>.ID);
-					archetype.Block(ComponentID<T10>.ID);
+					archetype.Block(components);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -7940,6 +8100,21 @@ namespace Myriad.ECS.Worlds
 			var c9 = ComponentID<T9>.ID;
 			var c10 = ComponentID<T10>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -7976,17 +8151,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -8544,23 +8709,28 @@ namespace Myriad.ECS.Worlds
 			var c10 = ComponentID<T10>.ID;
 			var c11 = ComponentID<T11>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(c0);
-				archetype.Block(c1);
-				archetype.Block(c2);
-				archetype.Block(c3);
-				archetype.Block(c4);
-				archetype.Block(c5);
-				archetype.Block(c6);
-				archetype.Block(c7);
-				archetype.Block(c8);
-				archetype.Block(c9);
-				archetype.Block(c10);
-				archetype.Block(c11);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -8708,6 +8878,22 @@ namespace Myriad.ECS.Worlds
 			var c10 = ComponentID<T10>.ID;
 			var c11 = ComponentID<T11>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+			};
+
 			var entityCount = 0;
 			var lastCompletedArchetype = default(Archetype);
 
@@ -8728,18 +8914,7 @@ namespace Myriad.ECS.Worlds
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
 
-					archetype.Block(ComponentID<T0>.ID);
-					archetype.Block(ComponentID<T1>.ID);
-					archetype.Block(ComponentID<T2>.ID);
-					archetype.Block(ComponentID<T3>.ID);
-					archetype.Block(ComponentID<T4>.ID);
-					archetype.Block(ComponentID<T5>.ID);
-					archetype.Block(ComponentID<T6>.ID);
-					archetype.Block(ComponentID<T7>.ID);
-					archetype.Block(ComponentID<T8>.ID);
-					archetype.Block(ComponentID<T9>.ID);
-					archetype.Block(ComponentID<T10>.ID);
-					archetype.Block(ComponentID<T11>.ID);
+					archetype.Block(components);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -8879,6 +9054,22 @@ namespace Myriad.ECS.Worlds
 			var c10 = ComponentID<T10>.ID;
 			var c11 = ComponentID<T11>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -8915,18 +9106,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -9506,24 +9686,29 @@ namespace Myriad.ECS.Worlds
 			var c11 = ComponentID<T11>.ID;
 			var c12 = ComponentID<T12>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+				c12,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(c0);
-				archetype.Block(c1);
-				archetype.Block(c2);
-				archetype.Block(c3);
-				archetype.Block(c4);
-				archetype.Block(c5);
-				archetype.Block(c6);
-				archetype.Block(c7);
-				archetype.Block(c8);
-				archetype.Block(c9);
-				archetype.Block(c10);
-				archetype.Block(c11);
-				archetype.Block(c12);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -9675,6 +9860,23 @@ namespace Myriad.ECS.Worlds
 			var c11 = ComponentID<T11>.ID;
 			var c12 = ComponentID<T12>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+				c12,
+			};
+
 			var entityCount = 0;
 			var lastCompletedArchetype = default(Archetype);
 
@@ -9695,19 +9897,7 @@ namespace Myriad.ECS.Worlds
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
 
-					archetype.Block(ComponentID<T0>.ID);
-					archetype.Block(ComponentID<T1>.ID);
-					archetype.Block(ComponentID<T2>.ID);
-					archetype.Block(ComponentID<T3>.ID);
-					archetype.Block(ComponentID<T4>.ID);
-					archetype.Block(ComponentID<T5>.ID);
-					archetype.Block(ComponentID<T6>.ID);
-					archetype.Block(ComponentID<T7>.ID);
-					archetype.Block(ComponentID<T8>.ID);
-					archetype.Block(ComponentID<T9>.ID);
-					archetype.Block(ComponentID<T10>.ID);
-					archetype.Block(ComponentID<T11>.ID);
-					archetype.Block(ComponentID<T12>.ID);
+					archetype.Block(components);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -9852,6 +10042,23 @@ namespace Myriad.ECS.Worlds
 			var c11 = ComponentID<T11>.ID;
 			var c12 = ComponentID<T12>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+				c12,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -9888,19 +10095,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -10502,25 +10697,30 @@ namespace Myriad.ECS.Worlds
 			var c12 = ComponentID<T12>.ID;
 			var c13 = ComponentID<T13>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+				c12,
+				c13,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(c0);
-				archetype.Block(c1);
-				archetype.Block(c2);
-				archetype.Block(c3);
-				archetype.Block(c4);
-				archetype.Block(c5);
-				archetype.Block(c6);
-				archetype.Block(c7);
-				archetype.Block(c8);
-				archetype.Block(c9);
-				archetype.Block(c10);
-				archetype.Block(c11);
-				archetype.Block(c12);
-				archetype.Block(c13);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -10676,6 +10876,24 @@ namespace Myriad.ECS.Worlds
 			var c12 = ComponentID<T12>.ID;
 			var c13 = ComponentID<T13>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+				c12,
+				c13,
+			};
+
 			var entityCount = 0;
 			var lastCompletedArchetype = default(Archetype);
 
@@ -10696,20 +10914,7 @@ namespace Myriad.ECS.Worlds
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
 
-					archetype.Block(ComponentID<T0>.ID);
-					archetype.Block(ComponentID<T1>.ID);
-					archetype.Block(ComponentID<T2>.ID);
-					archetype.Block(ComponentID<T3>.ID);
-					archetype.Block(ComponentID<T4>.ID);
-					archetype.Block(ComponentID<T5>.ID);
-					archetype.Block(ComponentID<T6>.ID);
-					archetype.Block(ComponentID<T7>.ID);
-					archetype.Block(ComponentID<T8>.ID);
-					archetype.Block(ComponentID<T9>.ID);
-					archetype.Block(ComponentID<T10>.ID);
-					archetype.Block(ComponentID<T11>.ID);
-					archetype.Block(ComponentID<T12>.ID);
-					archetype.Block(ComponentID<T13>.ID);
+					archetype.Block(components);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -10859,6 +11064,24 @@ namespace Myriad.ECS.Worlds
 			var c12 = ComponentID<T12>.ID;
 			var c13 = ComponentID<T13>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+				c12,
+				c13,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -10895,20 +11118,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
-				archetype.Block(ComponentID<T13>.ID);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -11532,26 +11742,31 @@ namespace Myriad.ECS.Worlds
 			var c13 = ComponentID<T13>.ID;
 			var c14 = ComponentID<T14>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+				c12,
+				c13,
+				c14,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(c0);
-				archetype.Block(c1);
-				archetype.Block(c2);
-				archetype.Block(c3);
-				archetype.Block(c4);
-				archetype.Block(c5);
-				archetype.Block(c6);
-				archetype.Block(c7);
-				archetype.Block(c8);
-				archetype.Block(c9);
-				archetype.Block(c10);
-				archetype.Block(c11);
-				archetype.Block(c12);
-				archetype.Block(c13);
-				archetype.Block(c14);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -11711,6 +11926,25 @@ namespace Myriad.ECS.Worlds
 			var c13 = ComponentID<T13>.ID;
 			var c14 = ComponentID<T14>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+				c12,
+				c13,
+				c14,
+			};
+
 			var entityCount = 0;
 			var lastCompletedArchetype = default(Archetype);
 
@@ -11731,21 +11965,7 @@ namespace Myriad.ECS.Worlds
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
 
-					archetype.Block(ComponentID<T0>.ID);
-					archetype.Block(ComponentID<T1>.ID);
-					archetype.Block(ComponentID<T2>.ID);
-					archetype.Block(ComponentID<T3>.ID);
-					archetype.Block(ComponentID<T4>.ID);
-					archetype.Block(ComponentID<T5>.ID);
-					archetype.Block(ComponentID<T6>.ID);
-					archetype.Block(ComponentID<T7>.ID);
-					archetype.Block(ComponentID<T8>.ID);
-					archetype.Block(ComponentID<T9>.ID);
-					archetype.Block(ComponentID<T10>.ID);
-					archetype.Block(ComponentID<T11>.ID);
-					archetype.Block(ComponentID<T12>.ID);
-					archetype.Block(ComponentID<T13>.ID);
-					archetype.Block(ComponentID<T14>.ID);
+					archetype.Block(components);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -11900,6 +12120,25 @@ namespace Myriad.ECS.Worlds
 			var c13 = ComponentID<T13>.ID;
 			var c14 = ComponentID<T14>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+				c12,
+				c13,
+				c14,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -11936,21 +12175,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
-				archetype.Block(ComponentID<T13>.ID);
-				archetype.Block(ComponentID<T14>.ID);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -12596,27 +12821,32 @@ namespace Myriad.ECS.Worlds
 			var c14 = ComponentID<T14>.ID;
 			var c15 = ComponentID<T15>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+				c12,
+				c13,
+				c14,
+				c15,
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(c0);
-				archetype.Block(c1);
-				archetype.Block(c2);
-				archetype.Block(c3);
-				archetype.Block(c4);
-				archetype.Block(c5);
-				archetype.Block(c6);
-				archetype.Block(c7);
-				archetype.Block(c8);
-				archetype.Block(c9);
-				archetype.Block(c10);
-				archetype.Block(c11);
-				archetype.Block(c12);
-				archetype.Block(c13);
-				archetype.Block(c14);
-				archetype.Block(c15);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 
@@ -12780,6 +13010,26 @@ namespace Myriad.ECS.Worlds
 			var c14 = ComponentID<T14>.ID;
 			var c15 = ComponentID<T15>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+				c12,
+				c13,
+				c14,
+				c15,
+			};
+
 			var entityCount = 0;
 			var lastCompletedArchetype = default(Archetype);
 
@@ -12800,22 +13050,7 @@ namespace Myriad.ECS.Worlds
 				{
 					var archetype = archetypesEnumerator.Current.Archetype;
 
-					archetype.Block(ComponentID<T0>.ID);
-					archetype.Block(ComponentID<T1>.ID);
-					archetype.Block(ComponentID<T2>.ID);
-					archetype.Block(ComponentID<T3>.ID);
-					archetype.Block(ComponentID<T4>.ID);
-					archetype.Block(ComponentID<T5>.ID);
-					archetype.Block(ComponentID<T6>.ID);
-					archetype.Block(ComponentID<T7>.ID);
-					archetype.Block(ComponentID<T8>.ID);
-					archetype.Block(ComponentID<T9>.ID);
-					archetype.Block(ComponentID<T10>.ID);
-					archetype.Block(ComponentID<T11>.ID);
-					archetype.Block(ComponentID<T12>.ID);
-					archetype.Block(ComponentID<T13>.ID);
-					archetype.Block(ComponentID<T14>.ID);
-					archetype.Block(ComponentID<T15>.ID);
+					archetype.Block(components);
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -12975,6 +13210,26 @@ namespace Myriad.ECS.Worlds
 			var c14 = ComponentID<T14>.ID;
 			var c15 = ComponentID<T15>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+				c12,
+				c13,
+				c14,
+				c15,
+			};
+
 			#region Parallel Work Loop Setup
 			// Borrow a counter which will be used to keep track of all in-progress work
 			using var workCounterRental = Pool<CountdownEventContainer>.Rent();
@@ -13011,22 +13266,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
-				archetype.Block(ComponentID<T13>.ID);
-				archetype.Block(ComponentID<T14>.ID);
-				archetype.Block(ComponentID<T15>.ID);
+					archetype.Block(components);
 
 				count += archetype.EntityCount;
 

--- a/Myriad.ECS/Queries/IQuery.tt
+++ b/Myriad.ECS/Queries/IQuery.tt
@@ -219,21 +219,27 @@ namespace Myriad.ECS.Worlds
 }
 #>
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+<# for (var k = 0; k < i; k++)
+{
+#>
+				c<#= k #>,
+<#
+}
+#>
+			};
+
 			var count = 0;
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
 <# if (i == 0) { #>
-				archetype.Block();
+					archetype.Block();
+<# } else { #>
+					archetype.Block(components);
 <# } #>
-<# for (var k = 0; k < i; k++)
-{
-#>
-				archetype.Block(c<#= k #>);
-<#
-}
-#>
 
 				count += archetype.EntityCount;
 
@@ -340,6 +346,17 @@ namespace Myriad.ECS.Worlds
 }
 #>
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+<# for (var k = 0; k < i; k++)
+{
+#>
+				c<#= k #>,
+<#
+}
+#>
+			};
+
 			var entityCount = 0;
 			var lastCompletedArchetype = default(Archetype);
 
@@ -361,15 +378,10 @@ namespace Myriad.ECS.Worlds
 					var archetype = archetypesEnumerator.Current.Archetype;
 
 <# if (i == 0) { #>
-				archetype.Block();
+					archetype.Block();
+<# } else { #>
+					archetype.Block(components);
 <# } #>
-<# for (var k = 0; k < i; k++)
-{
-#>
-					archetype.Block(ComponentID<T<#= k #>>.ID);
-<#
-}
-#>
 
 					var chunks = archetype.GetChunkEnumerator();
 					try
@@ -466,6 +478,17 @@ namespace Myriad.ECS.Worlds
 }
 #>
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+<# for (var k = 0; k < i; k++)
+{
+#>
+				c<#= k #>,
+<#
+}
+#>
+			};
+
 <#
 			EmitParallelWorkLoopSetup(workItemName);
 #>
@@ -479,15 +502,10 @@ namespace Myriad.ECS.Worlds
 					continue;
 
 <# if (i == 0) { #>
-				archetype.Block();
+					archetype.Block();
+<# } else { #>
+					archetype.Block(components);
 <# } #>
-<# for (var k = 0; k < i; k++)
-{
-#>
-				archetype.Block(ComponentID<T<#= k #>>.ID);
-<#
-}
-#>
 
 				count += archetype.EntityCount;
 

--- a/Myriad.ECS/Queries/IVectorChunkQuery.cs
+++ b/Myriad.ECS/Queries/IVectorChunkQuery.cs
@@ -60,6 +60,11 @@ namespace Myriad.ECS.Worlds
 
 		    var c0 = ComponentID<T0>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+			};
+
 			// Allocate some spans we need to copy the "leftover" values
 			Span<TV0> lvs0 = stackalloc TV0[Vector<TV0>.Count];
 
@@ -70,7 +75,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -184,6 +189,12 @@ namespace Myriad.ECS.Worlds
 		    var c0 = ComponentID<T0>.ID;
 		    var c1 = ComponentID<T1>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+			};
+
 			// Allocate some spans we need to copy the "leftover" values
 			Span<TV0> lvs0 = stackalloc TV0[Vector<TV0>.Count];
 			Span<TV1> lvs1 = stackalloc TV1[Vector<TV1>.Count];
@@ -195,8 +206,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -327,6 +337,13 @@ namespace Myriad.ECS.Worlds
 		    var c1 = ComponentID<T1>.ID;
 		    var c2 = ComponentID<T2>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+			};
+
 			// Allocate some spans we need to copy the "leftover" values
 			Span<TV0> lvs0 = stackalloc TV0[Vector<TV0>.Count];
 			Span<TV1> lvs1 = stackalloc TV1[Vector<TV1>.Count];
@@ -339,9 +356,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -489,6 +504,14 @@ namespace Myriad.ECS.Worlds
 		    var c2 = ComponentID<T2>.ID;
 		    var c3 = ComponentID<T3>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+			};
+
 			// Allocate some spans we need to copy the "leftover" values
 			Span<TV0> lvs0 = stackalloc TV0[Vector<TV0>.Count];
 			Span<TV1> lvs1 = stackalloc TV1[Vector<TV1>.Count];
@@ -502,10 +525,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -670,6 +690,15 @@ namespace Myriad.ECS.Worlds
 		    var c3 = ComponentID<T3>.ID;
 		    var c4 = ComponentID<T4>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+			};
+
 			// Allocate some spans we need to copy the "leftover" values
 			Span<TV0> lvs0 = stackalloc TV0[Vector<TV0>.Count];
 			Span<TV1> lvs1 = stackalloc TV1[Vector<TV1>.Count];
@@ -684,11 +713,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -870,6 +895,16 @@ namespace Myriad.ECS.Worlds
 		    var c4 = ComponentID<T4>.ID;
 		    var c5 = ComponentID<T5>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+			};
+
 			// Allocate some spans we need to copy the "leftover" values
 			Span<TV0> lvs0 = stackalloc TV0[Vector<TV0>.Count];
 			Span<TV1> lvs1 = stackalloc TV1[Vector<TV1>.Count];
@@ -885,12 +920,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -1089,6 +1119,17 @@ namespace Myriad.ECS.Worlds
 		    var c5 = ComponentID<T5>.ID;
 		    var c6 = ComponentID<T6>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+			};
+
 			// Allocate some spans we need to copy the "leftover" values
 			Span<TV0> lvs0 = stackalloc TV0[Vector<TV0>.Count];
 			Span<TV1> lvs1 = stackalloc TV1[Vector<TV1>.Count];
@@ -1105,13 +1146,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -1327,6 +1362,18 @@ namespace Myriad.ECS.Worlds
 		    var c6 = ComponentID<T6>.ID;
 		    var c7 = ComponentID<T7>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+			};
+
 			// Allocate some spans we need to copy the "leftover" values
 			Span<TV0> lvs0 = stackalloc TV0[Vector<TV0>.Count];
 			Span<TV1> lvs1 = stackalloc TV1[Vector<TV1>.Count];
@@ -1344,14 +1391,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -1584,6 +1624,19 @@ namespace Myriad.ECS.Worlds
 		    var c7 = ComponentID<T7>.ID;
 		    var c8 = ComponentID<T8>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+			};
+
 			// Allocate some spans we need to copy the "leftover" values
 			Span<TV0> lvs0 = stackalloc TV0[Vector<TV0>.Count];
 			Span<TV1> lvs1 = stackalloc TV1[Vector<TV1>.Count];
@@ -1602,15 +1655,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -1860,6 +1905,20 @@ namespace Myriad.ECS.Worlds
 		    var c8 = ComponentID<T8>.ID;
 		    var c9 = ComponentID<T9>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+			};
+
 			// Allocate some spans we need to copy the "leftover" values
 			Span<TV0> lvs0 = stackalloc TV0[Vector<TV0>.Count];
 			Span<TV1> lvs1 = stackalloc TV1[Vector<TV1>.Count];
@@ -1879,16 +1938,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -2155,6 +2205,21 @@ namespace Myriad.ECS.Worlds
 		    var c9 = ComponentID<T9>.ID;
 		    var c10 = ComponentID<T10>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+			};
+
 			// Allocate some spans we need to copy the "leftover" values
 			Span<TV0> lvs0 = stackalloc TV0[Vector<TV0>.Count];
 			Span<TV1> lvs1 = stackalloc TV1[Vector<TV1>.Count];
@@ -2175,17 +2240,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -2469,6 +2524,22 @@ namespace Myriad.ECS.Worlds
 		    var c10 = ComponentID<T10>.ID;
 		    var c11 = ComponentID<T11>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+			};
+
 			// Allocate some spans we need to copy the "leftover" values
 			Span<TV0> lvs0 = stackalloc TV0[Vector<TV0>.Count];
 			Span<TV1> lvs1 = stackalloc TV1[Vector<TV1>.Count];
@@ -2490,18 +2561,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -2802,6 +2862,23 @@ namespace Myriad.ECS.Worlds
 		    var c11 = ComponentID<T11>.ID;
 		    var c12 = ComponentID<T12>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+				c12,
+			};
+
 			// Allocate some spans we need to copy the "leftover" values
 			Span<TV0> lvs0 = stackalloc TV0[Vector<TV0>.Count];
 			Span<TV1> lvs1 = stackalloc TV1[Vector<TV1>.Count];
@@ -2824,19 +2901,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -3154,6 +3219,24 @@ namespace Myriad.ECS.Worlds
 		    var c12 = ComponentID<T12>.ID;
 		    var c13 = ComponentID<T13>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+				c12,
+				c13,
+			};
+
 			// Allocate some spans we need to copy the "leftover" values
 			Span<TV0> lvs0 = stackalloc TV0[Vector<TV0>.Count];
 			Span<TV1> lvs1 = stackalloc TV1[Vector<TV1>.Count];
@@ -3177,20 +3260,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
-				archetype.Block(ComponentID<T13>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -3525,6 +3595,25 @@ namespace Myriad.ECS.Worlds
 		    var c13 = ComponentID<T13>.ID;
 		    var c14 = ComponentID<T14>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+				c12,
+				c13,
+				c14,
+			};
+
 			// Allocate some spans we need to copy the "leftover" values
 			Span<TV0> lvs0 = stackalloc TV0[Vector<TV0>.Count];
 			Span<TV1> lvs1 = stackalloc TV1[Vector<TV1>.Count];
@@ -3549,21 +3638,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
-				archetype.Block(ComponentID<T13>.ID);
-				archetype.Block(ComponentID<T14>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -3915,6 +3990,26 @@ namespace Myriad.ECS.Worlds
 		    var c14 = ComponentID<T14>.ID;
 		    var c15 = ComponentID<T15>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+				c12,
+				c13,
+				c14,
+				c15,
+			};
+
 			// Allocate some spans we need to copy the "leftover" values
 			Span<TV0> lvs0 = stackalloc TV0[Vector<TV0>.Count];
 			Span<TV1> lvs1 = stackalloc TV1[Vector<TV1>.Count];
@@ -3940,22 +4035,7 @@ namespace Myriad.ECS.Worlds
 				if (archetype.EntityCount == 0)
 					continue;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
-				archetype.Block(ComponentID<T13>.ID);
-				archetype.Block(ComponentID<T14>.ID);
-				archetype.Block(ComponentID<T15>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)

--- a/Myriad.ECS/Queries/IVectorChunkQuery.tt
+++ b/Myriad.ECS/Queries/IVectorChunkQuery.tt
@@ -90,6 +90,17 @@ namespace Myriad.ECS.Worlds
 }
 #>
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+<# for (var k = 0; k < i; k++)
+{
+#>
+				c<#= k #>,
+<#
+}
+#>
+			};
+
 			// Allocate some spans we need to copy the "leftover" values
 <# for (var k = 0; k < sumij; k++)
 {
@@ -106,14 +117,9 @@ namespace Myriad.ECS.Worlds
 
 <# if (sumij == 0) { #>
 				archetype.Block();
+<# } else { #>
+				archetype.Block(components);
 <# } #>
-<# for (var k = 0; k < sumij; k++)
-{
-#>
-				archetype.Block(ComponentID<T<#= k #>>.ID);
-<#
-}
-#>
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)

--- a/Myriad.ECS/Queries/QueryDescription.cs
+++ b/Myriad.ECS/Queries/QueryDescription.cs
@@ -616,6 +616,8 @@ public sealed class QueryDescription
         if (IsExcluded(id))
             return 0;
 
+        Span<ComponentID> component = stackalloc[] { id };
+
         var count = 0;
         foreach (var match in GetArchetypes())
         {
@@ -625,7 +627,7 @@ public sealed class QueryDescription
             count += match.Archetype.EntityCount;
 
             // Wait for multithreaded access to this component in this archetype
-            match.Archetype.Block(stackalloc [] { id });
+            match.Archetype.Block(component);
 
             using var chunks = match.Archetype.GetChunkEnumerator();
             while (chunks.MoveNext())

--- a/Myriad.ECS/Queries/QueryDescription.cs
+++ b/Myriad.ECS/Queries/QueryDescription.cs
@@ -625,7 +625,7 @@ public sealed class QueryDescription
             count += match.Archetype.EntityCount;
 
             // Wait for multithreaded access to this component in this archetype
-            match.Archetype.Block(id);
+            match.Archetype.Block(stackalloc [] { id });
 
             using var chunks = match.Archetype.GetChunkEnumerator();
             while (chunks.MoveNext())

--- a/Myriad.ECS/Queries/QueryEnumerable.cs
+++ b/Myriad.ECS/Queries/QueryEnumerable.cs
@@ -76,10 +76,6 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
-                Span<ComponentID> components = stackalloc ComponentID[]
-			    {
-			    };
-
                 var archetype = _archetypesEnumerator.Current.Archetype;
 				archetype.Block();
 
@@ -213,12 +209,12 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                var archetype = _archetypesEnumerator.Current.Archetype;
                 Span<ComponentID> components = stackalloc ComponentID[]
 			    {
 				    C0,
 			    };
 
-                var archetype = _archetypesEnumerator.Current.Archetype;
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -370,13 +366,13 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                var archetype = _archetypesEnumerator.Current.Archetype;
                 Span<ComponentID> components = stackalloc ComponentID[]
 			    {
 				    C0,
 				    C1,
 			    };
 
-                var archetype = _archetypesEnumerator.Current.Archetype;
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -537,6 +533,7 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                var archetype = _archetypesEnumerator.Current.Archetype;
                 Span<ComponentID> components = stackalloc ComponentID[]
 			    {
 				    C0,
@@ -544,7 +541,6 @@ namespace Myriad.ECS.Queries
 				    C2,
 			    };
 
-                var archetype = _archetypesEnumerator.Current.Archetype;
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -714,6 +710,7 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                var archetype = _archetypesEnumerator.Current.Archetype;
                 Span<ComponentID> components = stackalloc ComponentID[]
 			    {
 				    C0,
@@ -722,7 +719,6 @@ namespace Myriad.ECS.Queries
 				    C3,
 			    };
 
-                var archetype = _archetypesEnumerator.Current.Archetype;
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -901,6 +897,7 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                var archetype = _archetypesEnumerator.Current.Archetype;
                 Span<ComponentID> components = stackalloc ComponentID[]
 			    {
 				    C0,
@@ -910,7 +907,6 @@ namespace Myriad.ECS.Queries
 				    C4,
 			    };
 
-                var archetype = _archetypesEnumerator.Current.Archetype;
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -1098,6 +1094,7 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                var archetype = _archetypesEnumerator.Current.Archetype;
                 Span<ComponentID> components = stackalloc ComponentID[]
 			    {
 				    C0,
@@ -1108,7 +1105,6 @@ namespace Myriad.ECS.Queries
 				    C5,
 			    };
 
-                var archetype = _archetypesEnumerator.Current.Archetype;
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -1305,6 +1301,7 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                var archetype = _archetypesEnumerator.Current.Archetype;
                 Span<ComponentID> components = stackalloc ComponentID[]
 			    {
 				    C0,
@@ -1316,7 +1313,6 @@ namespace Myriad.ECS.Queries
 				    C6,
 			    };
 
-                var archetype = _archetypesEnumerator.Current.Archetype;
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -1522,6 +1518,7 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                var archetype = _archetypesEnumerator.Current.Archetype;
                 Span<ComponentID> components = stackalloc ComponentID[]
 			    {
 				    C0,
@@ -1534,7 +1531,6 @@ namespace Myriad.ECS.Queries
 				    C7,
 			    };
 
-                var archetype = _archetypesEnumerator.Current.Archetype;
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -1749,6 +1745,7 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                var archetype = _archetypesEnumerator.Current.Archetype;
                 Span<ComponentID> components = stackalloc ComponentID[]
 			    {
 				    C0,
@@ -1762,7 +1759,6 @@ namespace Myriad.ECS.Queries
 				    C8,
 			    };
 
-                var archetype = _archetypesEnumerator.Current.Archetype;
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -1986,6 +1982,7 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                var archetype = _archetypesEnumerator.Current.Archetype;
                 Span<ComponentID> components = stackalloc ComponentID[]
 			    {
 				    C0,
@@ -2000,7 +1997,6 @@ namespace Myriad.ECS.Queries
 				    C9,
 			    };
 
-                var archetype = _archetypesEnumerator.Current.Archetype;
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -2233,6 +2229,7 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                var archetype = _archetypesEnumerator.Current.Archetype;
                 Span<ComponentID> components = stackalloc ComponentID[]
 			    {
 				    C0,
@@ -2248,7 +2245,6 @@ namespace Myriad.ECS.Queries
 				    C10,
 			    };
 
-                var archetype = _archetypesEnumerator.Current.Archetype;
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -2490,6 +2486,7 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                var archetype = _archetypesEnumerator.Current.Archetype;
                 Span<ComponentID> components = stackalloc ComponentID[]
 			    {
 				    C0,
@@ -2506,7 +2503,6 @@ namespace Myriad.ECS.Queries
 				    C11,
 			    };
 
-                var archetype = _archetypesEnumerator.Current.Archetype;
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -2757,6 +2753,7 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                var archetype = _archetypesEnumerator.Current.Archetype;
                 Span<ComponentID> components = stackalloc ComponentID[]
 			    {
 				    C0,
@@ -2774,7 +2771,6 @@ namespace Myriad.ECS.Queries
 				    C12,
 			    };
 
-                var archetype = _archetypesEnumerator.Current.Archetype;
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -3034,6 +3030,7 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                var archetype = _archetypesEnumerator.Current.Archetype;
                 Span<ComponentID> components = stackalloc ComponentID[]
 			    {
 				    C0,
@@ -3052,7 +3049,6 @@ namespace Myriad.ECS.Queries
 				    C13,
 			    };
 
-                var archetype = _archetypesEnumerator.Current.Archetype;
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -3321,6 +3317,7 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                var archetype = _archetypesEnumerator.Current.Archetype;
                 Span<ComponentID> components = stackalloc ComponentID[]
 			    {
 				    C0,
@@ -3340,7 +3337,6 @@ namespace Myriad.ECS.Queries
 				    C14,
 			    };
 
-                var archetype = _archetypesEnumerator.Current.Archetype;
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -3618,6 +3614,7 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                var archetype = _archetypesEnumerator.Current.Archetype;
                 Span<ComponentID> components = stackalloc ComponentID[]
 			    {
 				    C0,
@@ -3638,7 +3635,6 @@ namespace Myriad.ECS.Queries
 				    C15,
 			    };
 
-                var archetype = _archetypesEnumerator.Current.Archetype;
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there

--- a/Myriad.ECS/Queries/QueryEnumerable.cs
+++ b/Myriad.ECS/Queries/QueryEnumerable.cs
@@ -378,7 +378,6 @@ namespace Myriad.ECS.Queries
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
 				archetype.Block(components);
-				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -546,8 +545,6 @@ namespace Myriad.ECS.Queries
 			    };
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(components);
-				archetype.Block(components);
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -726,9 +723,6 @@ namespace Myriad.ECS.Queries
 			    };
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -917,10 +911,6 @@ namespace Myriad.ECS.Queries
 			    };
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -1119,11 +1109,6 @@ namespace Myriad.ECS.Queries
 			    };
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -1332,12 +1317,6 @@ namespace Myriad.ECS.Queries
 			    };
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -1556,13 +1535,6 @@ namespace Myriad.ECS.Queries
 			    };
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -1791,14 +1763,6 @@ namespace Myriad.ECS.Queries
 			    };
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -2037,15 +2001,6 @@ namespace Myriad.ECS.Queries
 			    };
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -2294,16 +2249,6 @@ namespace Myriad.ECS.Queries
 			    };
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -2562,17 +2507,6 @@ namespace Myriad.ECS.Queries
 			    };
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -2841,18 +2775,6 @@ namespace Myriad.ECS.Queries
 			    };
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -3131,19 +3053,6 @@ namespace Myriad.ECS.Queries
 			    };
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -3432,20 +3341,6 @@ namespace Myriad.ECS.Queries
 			    };
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
@@ -3744,21 +3639,6 @@ namespace Myriad.ECS.Queries
 			    };
 
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
-				archetype.Block(components);
 				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there

--- a/Myriad.ECS/Queries/QueryEnumerable.cs
+++ b/Myriad.ECS/Queries/QueryEnumerable.cs
@@ -76,6 +76,10 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                Span<ComponentID> components = stackalloc ComponentID[]
+			    {
+			    };
+
                 var archetype = _archetypesEnumerator.Current.Archetype;
 				archetype.Block();
 
@@ -209,8 +213,13 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                Span<ComponentID> components = stackalloc ComponentID[]
+			    {
+				    C0,
+			    };
+
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(C0);
+				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -361,9 +370,15 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                Span<ComponentID> components = stackalloc ComponentID[]
+			    {
+				    C0,
+				    C1,
+			    };
+
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(C0);
-				archetype.Block(C1);
+				archetype.Block(components);
+				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -523,10 +538,17 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                Span<ComponentID> components = stackalloc ComponentID[]
+			    {
+				    C0,
+				    C1,
+				    C2,
+			    };
+
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(C0);
-				archetype.Block(C1);
-				archetype.Block(C2);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -695,11 +717,19 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                Span<ComponentID> components = stackalloc ComponentID[]
+			    {
+				    C0,
+				    C1,
+				    C2,
+				    C3,
+			    };
+
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(C0);
-				archetype.Block(C1);
-				archetype.Block(C2);
-				archetype.Block(C3);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -877,12 +907,21 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                Span<ComponentID> components = stackalloc ComponentID[]
+			    {
+				    C0,
+				    C1,
+				    C2,
+				    C3,
+				    C4,
+			    };
+
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(C0);
-				archetype.Block(C1);
-				archetype.Block(C2);
-				archetype.Block(C3);
-				archetype.Block(C4);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -1069,13 +1108,23 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                Span<ComponentID> components = stackalloc ComponentID[]
+			    {
+				    C0,
+				    C1,
+				    C2,
+				    C3,
+				    C4,
+				    C5,
+			    };
+
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(C0);
-				archetype.Block(C1);
-				archetype.Block(C2);
-				archetype.Block(C3);
-				archetype.Block(C4);
-				archetype.Block(C5);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -1271,14 +1320,25 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                Span<ComponentID> components = stackalloc ComponentID[]
+			    {
+				    C0,
+				    C1,
+				    C2,
+				    C3,
+				    C4,
+				    C5,
+				    C6,
+			    };
+
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(C0);
-				archetype.Block(C1);
-				archetype.Block(C2);
-				archetype.Block(C3);
-				archetype.Block(C4);
-				archetype.Block(C5);
-				archetype.Block(C6);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -1483,15 +1543,27 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                Span<ComponentID> components = stackalloc ComponentID[]
+			    {
+				    C0,
+				    C1,
+				    C2,
+				    C3,
+				    C4,
+				    C5,
+				    C6,
+				    C7,
+			    };
+
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(C0);
-				archetype.Block(C1);
-				archetype.Block(C2);
-				archetype.Block(C3);
-				archetype.Block(C4);
-				archetype.Block(C5);
-				archetype.Block(C6);
-				archetype.Block(C7);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -1705,16 +1777,29 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                Span<ComponentID> components = stackalloc ComponentID[]
+			    {
+				    C0,
+				    C1,
+				    C2,
+				    C3,
+				    C4,
+				    C5,
+				    C6,
+				    C7,
+				    C8,
+			    };
+
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(C0);
-				archetype.Block(C1);
-				archetype.Block(C2);
-				archetype.Block(C3);
-				archetype.Block(C4);
-				archetype.Block(C5);
-				archetype.Block(C6);
-				archetype.Block(C7);
-				archetype.Block(C8);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -1937,17 +2022,31 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                Span<ComponentID> components = stackalloc ComponentID[]
+			    {
+				    C0,
+				    C1,
+				    C2,
+				    C3,
+				    C4,
+				    C5,
+				    C6,
+				    C7,
+				    C8,
+				    C9,
+			    };
+
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(C0);
-				archetype.Block(C1);
-				archetype.Block(C2);
-				archetype.Block(C3);
-				archetype.Block(C4);
-				archetype.Block(C5);
-				archetype.Block(C6);
-				archetype.Block(C7);
-				archetype.Block(C8);
-				archetype.Block(C9);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -2179,18 +2278,33 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                Span<ComponentID> components = stackalloc ComponentID[]
+			    {
+				    C0,
+				    C1,
+				    C2,
+				    C3,
+				    C4,
+				    C5,
+				    C6,
+				    C7,
+				    C8,
+				    C9,
+				    C10,
+			    };
+
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(C0);
-				archetype.Block(C1);
-				archetype.Block(C2);
-				archetype.Block(C3);
-				archetype.Block(C4);
-				archetype.Block(C5);
-				archetype.Block(C6);
-				archetype.Block(C7);
-				archetype.Block(C8);
-				archetype.Block(C9);
-				archetype.Block(C10);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -2431,19 +2545,35 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                Span<ComponentID> components = stackalloc ComponentID[]
+			    {
+				    C0,
+				    C1,
+				    C2,
+				    C3,
+				    C4,
+				    C5,
+				    C6,
+				    C7,
+				    C8,
+				    C9,
+				    C10,
+				    C11,
+			    };
+
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(C0);
-				archetype.Block(C1);
-				archetype.Block(C2);
-				archetype.Block(C3);
-				archetype.Block(C4);
-				archetype.Block(C5);
-				archetype.Block(C6);
-				archetype.Block(C7);
-				archetype.Block(C8);
-				archetype.Block(C9);
-				archetype.Block(C10);
-				archetype.Block(C11);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -2693,20 +2823,37 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                Span<ComponentID> components = stackalloc ComponentID[]
+			    {
+				    C0,
+				    C1,
+				    C2,
+				    C3,
+				    C4,
+				    C5,
+				    C6,
+				    C7,
+				    C8,
+				    C9,
+				    C10,
+				    C11,
+				    C12,
+			    };
+
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(C0);
-				archetype.Block(C1);
-				archetype.Block(C2);
-				archetype.Block(C3);
-				archetype.Block(C4);
-				archetype.Block(C5);
-				archetype.Block(C6);
-				archetype.Block(C7);
-				archetype.Block(C8);
-				archetype.Block(C9);
-				archetype.Block(C10);
-				archetype.Block(C11);
-				archetype.Block(C12);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -2965,21 +3112,39 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                Span<ComponentID> components = stackalloc ComponentID[]
+			    {
+				    C0,
+				    C1,
+				    C2,
+				    C3,
+				    C4,
+				    C5,
+				    C6,
+				    C7,
+				    C8,
+				    C9,
+				    C10,
+				    C11,
+				    C12,
+				    C13,
+			    };
+
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(C0);
-				archetype.Block(C1);
-				archetype.Block(C2);
-				archetype.Block(C3);
-				archetype.Block(C4);
-				archetype.Block(C5);
-				archetype.Block(C6);
-				archetype.Block(C7);
-				archetype.Block(C8);
-				archetype.Block(C9);
-				archetype.Block(C10);
-				archetype.Block(C11);
-				archetype.Block(C12);
-				archetype.Block(C13);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -3247,22 +3412,41 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                Span<ComponentID> components = stackalloc ComponentID[]
+			    {
+				    C0,
+				    C1,
+				    C2,
+				    C3,
+				    C4,
+				    C5,
+				    C6,
+				    C7,
+				    C8,
+				    C9,
+				    C10,
+				    C11,
+				    C12,
+				    C13,
+				    C14,
+			    };
+
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(C0);
-				archetype.Block(C1);
-				archetype.Block(C2);
-				archetype.Block(C3);
-				archetype.Block(C4);
-				archetype.Block(C5);
-				archetype.Block(C6);
-				archetype.Block(C7);
-				archetype.Block(C8);
-				archetype.Block(C9);
-				archetype.Block(C10);
-				archetype.Block(C11);
-				archetype.Block(C12);
-				archetype.Block(C13);
-				archetype.Block(C14);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.
@@ -3539,23 +3723,43 @@ namespace Myriad.ECS.Queries
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                Span<ComponentID> components = stackalloc ComponentID[]
+			    {
+				    C0,
+				    C1,
+				    C2,
+				    C3,
+				    C4,
+				    C5,
+				    C6,
+				    C7,
+				    C8,
+				    C9,
+				    C10,
+				    C11,
+				    C12,
+				    C13,
+				    C14,
+				    C15,
+			    };
+
                 var archetype = _archetypesEnumerator.Current.Archetype;
-				archetype.Block(C0);
-				archetype.Block(C1);
-				archetype.Block(C2);
-				archetype.Block(C3);
-				archetype.Block(C4);
-				archetype.Block(C5);
-				archetype.Block(C6);
-				archetype.Block(C7);
-				archetype.Block(C8);
-				archetype.Block(C9);
-				archetype.Block(C10);
-				archetype.Block(C11);
-				archetype.Block(C12);
-				archetype.Block(C13);
-				archetype.Block(C14);
-				archetype.Block(C15);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
+				archetype.Block(components);
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.

--- a/Myriad.ECS/Queries/QueryEnumerable.tt
+++ b/Myriad.ECS/Queries/QueryEnumerable.tt
@@ -171,14 +171,9 @@ for (var k = 0; k < i; k++)
                 var archetype = _archetypesEnumerator.Current.Archetype;
 <# if (i == 0) { #>
 				archetype.Block();
-<# } #>
-<# for (var k = 0; k < i; k++)
-{
-#>
+<# } else { #>
 				archetype.Block(components);
-<#
-}
-#>
+<# } #>
 
                 // Try to move to the next (first) chunk of this archetype. Might fail if there
                 // are no chunks in this archetype.

--- a/Myriad.ECS/Queries/QueryEnumerable.tt
+++ b/Myriad.ECS/Queries/QueryEnumerable.tt
@@ -157,6 +157,10 @@ for (var k = 0; k < i; k++)
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                var archetype = _archetypesEnumerator.Current.Archetype;
+<# if (i == 0) { #>
+				archetype.Block();
+<# } else { #>
                 Span<ComponentID> components = stackalloc ComponentID[]
 			    {
 <# for (var k = 0; k < i; k++)
@@ -168,10 +172,6 @@ for (var k = 0; k < i; k++)
 #>
 			    };
 
-                var archetype = _archetypesEnumerator.Current.Archetype;
-<# if (i == 0) { #>
-				archetype.Block();
-<# } else { #>
 				archetype.Block(components);
 <# } #>
 

--- a/Myriad.ECS/Queries/QueryEnumerable.tt
+++ b/Myriad.ECS/Queries/QueryEnumerable.tt
@@ -157,6 +157,17 @@ for (var k = 0; k < i; k++)
                 if (!_archetypesEnumerator.MoveNext())
                     return false;
 
+                Span<ComponentID> components = stackalloc ComponentID[]
+			    {
+<# for (var k = 0; k < i; k++)
+{
+#>
+				    C<#= k #>,
+<#
+}
+#>
+			    };
+
                 var archetype = _archetypesEnumerator.Current.Archetype;
 <# if (i == 0) { #>
 				archetype.Block();
@@ -164,7 +175,7 @@ for (var k = 0; k < i; k++)
 <# for (var k = 0; k < i; k++)
 {
 #>
-				archetype.Block(C<#= k #>);
+				archetype.Block(components);
 <#
 }
 #>

--- a/Myriad.ECS/Queries/QueryMapReduce.cs
+++ b/Myriad.ECS/Queries/QueryMapReduce.cs
@@ -254,13 +254,18 @@ namespace Myriad.ECS.Worlds
 
 			var c0 = ComponentID<T0>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+			};
+
 			var accumulator = initial;
 
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -520,14 +525,19 @@ namespace Myriad.ECS.Worlds
 			var c0 = ComponentID<T0>.ID;
 			var c1 = ComponentID<T1>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+			};
+
 			var accumulator = initial;
 
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -801,15 +811,20 @@ namespace Myriad.ECS.Worlds
 			var c1 = ComponentID<T1>.ID;
 			var c2 = ComponentID<T2>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+			};
+
 			var accumulator = initial;
 
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -1097,16 +1112,21 @@ namespace Myriad.ECS.Worlds
 			var c2 = ComponentID<T2>.ID;
 			var c3 = ComponentID<T3>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+			};
+
 			var accumulator = initial;
 
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -1408,17 +1428,22 @@ namespace Myriad.ECS.Worlds
 			var c3 = ComponentID<T3>.ID;
 			var c4 = ComponentID<T4>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+			};
+
 			var accumulator = initial;
 
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -1734,18 +1759,23 @@ namespace Myriad.ECS.Worlds
 			var c4 = ComponentID<T4>.ID;
 			var c5 = ComponentID<T5>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+			};
+
 			var accumulator = initial;
 
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -2075,19 +2105,24 @@ namespace Myriad.ECS.Worlds
 			var c5 = ComponentID<T5>.ID;
 			var c6 = ComponentID<T6>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+			};
+
 			var accumulator = initial;
 
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -2431,20 +2466,25 @@ namespace Myriad.ECS.Worlds
 			var c6 = ComponentID<T6>.ID;
 			var c7 = ComponentID<T7>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+			};
+
 			var accumulator = initial;
 
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -2802,21 +2842,26 @@ namespace Myriad.ECS.Worlds
 			var c7 = ComponentID<T7>.ID;
 			var c8 = ComponentID<T8>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+			};
+
 			var accumulator = initial;
 
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -3188,22 +3233,27 @@ namespace Myriad.ECS.Worlds
 			var c8 = ComponentID<T8>.ID;
 			var c9 = ComponentID<T9>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+			};
+
 			var accumulator = initial;
 
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -3589,23 +3639,28 @@ namespace Myriad.ECS.Worlds
 			var c9 = ComponentID<T9>.ID;
 			var c10 = ComponentID<T10>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+			};
+
 			var accumulator = initial;
 
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -4005,24 +4060,29 @@ namespace Myriad.ECS.Worlds
 			var c10 = ComponentID<T10>.ID;
 			var c11 = ComponentID<T11>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+			};
+
 			var accumulator = initial;
 
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -4436,25 +4496,30 @@ namespace Myriad.ECS.Worlds
 			var c11 = ComponentID<T11>.ID;
 			var c12 = ComponentID<T12>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+				c12,
+			};
+
 			var accumulator = initial;
 
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -4882,26 +4947,31 @@ namespace Myriad.ECS.Worlds
 			var c12 = ComponentID<T12>.ID;
 			var c13 = ComponentID<T13>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+				c12,
+				c13,
+			};
+
 			var accumulator = initial;
 
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
-				archetype.Block(ComponentID<T13>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -5343,27 +5413,32 @@ namespace Myriad.ECS.Worlds
 			var c13 = ComponentID<T13>.ID;
 			var c14 = ComponentID<T14>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+				c12,
+				c13,
+				c14,
+			};
+
 			var accumulator = initial;
 
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
-				archetype.Block(ComponentID<T13>.ID);
-				archetype.Block(ComponentID<T14>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)
@@ -5819,28 +5894,33 @@ namespace Myriad.ECS.Worlds
 			var c14 = ComponentID<T14>.ID;
 			var c15 = ComponentID<T15>.ID;
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+				c0,
+				c1,
+				c2,
+				c3,
+				c4,
+				c5,
+				c6,
+				c7,
+				c8,
+				c9,
+				c10,
+				c11,
+				c12,
+				c13,
+				c14,
+				c15,
+			};
+
 			var accumulator = initial;
 
 			foreach (var archetypeMatch in archetypes)
 			{
 			    var archetype = archetypeMatch.Archetype;
 
-				archetype.Block(ComponentID<T0>.ID);
-				archetype.Block(ComponentID<T1>.ID);
-				archetype.Block(ComponentID<T2>.ID);
-				archetype.Block(ComponentID<T3>.ID);
-				archetype.Block(ComponentID<T4>.ID);
-				archetype.Block(ComponentID<T5>.ID);
-				archetype.Block(ComponentID<T6>.ID);
-				archetype.Block(ComponentID<T7>.ID);
-				archetype.Block(ComponentID<T8>.ID);
-				archetype.Block(ComponentID<T9>.ID);
-				archetype.Block(ComponentID<T10>.ID);
-				archetype.Block(ComponentID<T11>.ID);
-				archetype.Block(ComponentID<T12>.ID);
-				archetype.Block(ComponentID<T13>.ID);
-				archetype.Block(ComponentID<T14>.ID);
-				archetype.Block(ComponentID<T15>.ID);
+				archetype.Block(components);
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)

--- a/Myriad.ECS/Queries/QueryMapReduce.tt
+++ b/Myriad.ECS/Queries/QueryMapReduce.tt
@@ -280,6 +280,17 @@ namespace Myriad.ECS.Worlds
 }
 #>
 
+			Span<ComponentID> components = stackalloc ComponentID[]
+			{
+<# for (var k = 0; k < i; k++)
+{
+#>
+				c<#= k #>,
+<#
+}
+#>
+			};
+
 			var accumulator = initial;
 
 			foreach (var archetypeMatch in archetypes)
@@ -288,14 +299,9 @@ namespace Myriad.ECS.Worlds
 
 <# if (i == 0) { #>
 				archetype.Block();
+<# } else { #>
+				archetype.Block(components);
 <# } #>
-<# for (var k = 0; k < sumij; k++)
-{
-#>
-				archetype.Block(ComponentID<T<#= k #>>.ID);
-<#
-}
-#>
 
 				var chunks = archetype.Chunks;
 				for (var c = chunks.Count - 1; c >= 0; c--)

--- a/Myriad.ECS/Worlds/Archetypes/Archetype.cs
+++ b/Myriad.ECS/Worlds/Archetypes/Archetype.cs
@@ -224,7 +224,7 @@ public sealed partial class Archetype
 
                 while (chunk.EntityCount > 0)
                 {
-                    var entity = chunk.Entities.Span[^1].ID;
+                    var entity = chunk.EntityIds.Span[^1];
                     ref var info = ref World.GetEntityInfo(entity);
 
                     MigrateTo(entity, ref info, _phantomDestination, ref lazy);
@@ -403,11 +403,11 @@ public sealed partial class Archetype
     }
 
     /// <summary>
-    /// Block on multithreaded access to the given component in this archetype to finish
+    /// Block on multithreaded access to the given components in this archetype to finish
     /// </summary>
-    public void Block(ComponentID id)
+    public void Block(ReadOnlySpan<ComponentID> ids)
     {
-        World.LockManager.Block(this, id);
+        World.LockManager.Block(this, ids);
     }
 
     /// <summary>


### PR DESCRIPTION
Modified blocking on archetypes to accept a span on component IDs. This allows for safety systems to block once, instead of adding overhead per-component.