### PR TITLE
Slightly Faster Migration Disposer Check

### DIFF
--- a/Myriad.ECS.Tests/Queries/ChunkHandleTests.cs
+++ b/Myriad.ECS.Tests/Queries/ChunkHandleTests.cs
@@ -41,6 +41,11 @@ public class ChunkHandleTests
                 ch.Entities.ToArray().Select(a => a.ID).ToArray()
             );
 
+            CollectionAssert.AreEqual(
+                danger.GetEntityIdArray().AsSpan(0, ch.EntityCount).ToArray(),
+                ch.EntityIds.ToArray()
+            );
+
             Assert.IsTrue(danger.GetComponentArray<ComponentInt32>().AsSpan(0, ch.EntityCount).SequenceEqual(ci));
         });
     }

--- a/Myriad.ECS/Myriad.ECS.csproj
+++ b/Myriad.ECS/Myriad.ECS.csproj
@@ -10,7 +10,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>Myriad.ECS</Title>
     <Authors>Martin Evans</Authors>
-    <Version>48.0.0</Version>
+    <Version>48.0.1</Version>
     <Description>Myriad.ECS is a high performance Entity Component System (ECS).</Description>
     <PackageProjectUrl>https://github.com/martindevans/Myriad.ECS</PackageProjectUrl>
     <RepositoryUrl>https://github.com/martindevans/Myriad.ECS</RepositoryUrl>

--- a/Myriad.ECS/Worlds/Archetypes/Archetype.cs
+++ b/Myriad.ECS/Worlds/Archetypes/Archetype.cs
@@ -325,7 +325,7 @@ public sealed partial class Archetype
         Debug.Assert(to != this);
 
         // Handle disposable components which are being removed
-        _disposer?.DisposeRemoved(ref lazy, info, to.Components);
+        _disposer?.DisposeRemoved(ref lazy, info, to);
 
         // Inform entity it is becoming a phantom
         if (to.IsPhantom)

--- a/Myriad.ECS/Worlds/Archetypes/ArchetypeComponentDisposal.cs
+++ b/Myriad.ECS/Worlds/Archetypes/ArchetypeComponentDisposal.cs
@@ -38,10 +38,10 @@ internal class ArchetypeComponentDisposal
     /// <param name="buffer"></param>
     /// <param name="info"></param>
     /// <param name="to"></param>
-    public void DisposeRemoved(ref LazyCommandBuffer buffer, EntityInfo info, FrozenOrderedListSet<ComponentID> to)
+    public void DisposeRemoved(ref LazyCommandBuffer buffer, EntityInfo info, Archetype to)
     {
         foreach (var disposer in _disposers)
-            if (!to.Contains(disposer.Component))
+            if (!to.HasComponent(disposer.Component))
                 disposer.Dispose(info.Chunk, info.RowIndex, ref buffer);
     }
 }


### PR DESCRIPTION
Using `Archetype.HasComponent` during entity migration for disposal check